### PR TITLE
Resolving issue #44 and adding improved reporting for TEAMEngine Console...

### DIFF
--- a/teamengine-core/src/main/java/com/occamlab/te/util/LogUtils.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/util/LogUtils.java
@@ -41,6 +41,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import com.occamlab.te.TECore;
+import javax.print.DocFlavor;
 
 public class LogUtils {
 
@@ -62,6 +63,8 @@ public class LogUtils {
             throws Exception {
         if (logDir != null) {
             File dir = new File(logDir, callpath);
+            String path=logDir.toString() + "/" + callpath.split("/")[0];
+            System.setProperty("PATH", path);
             dir.mkdir();
             File f = new File(dir, "log.xml");
             f.delete();


### PR DESCRIPTION
This Branch fix for issue #44  and enhancements to TEAMEngine Console reporting for CTL tests

Resolved Issue

-Error in call to extension function {public synchronized void com.occamlab.te.TECore.callTest(net.sf.saxon.expr.XPathContext,java.lang.String,java.lang.String,net.sf.saxon.om.NodeInfo,java.lang.String) throws java.lang.Exception}: Exception in extension function java.util.NoSuchElementException

In 'TEAMEngine-Core Module' in package pom.occamlab.te in the class TECore.java
in the method executeTest() , before popping an element from the Linked List 'testStack' there was no condition used to check whether the Linked List is empty or not. Hence while running a WFS 1.1.0 test the code use to try to pop and element from an empty Linked List and hence there was an error.

-  Parse Fatal Error at line 1 column 1: Content is not allowed in prolog.
org.xml.sax.SAXParseException: Content is not allowed in prolog.

This error is cause when your xml file has some invisible chars (most likely the byte order mark -BOM) at the start (before <?xml version="1.0" encoding="UTF-8"?>) which is not allowed in xml. You could view it using a hex editor.
This error occurs for all XML's under the base URL http://mrdata.usgs.gov/wfs/
Hence the prolog issue is not associated with the WFS 1.1.0 CTL test. The result XML that gets created for all the WFS XML's under http://mrdata.usgs.gov/wfs/ are same when you run the TEAMEngine WFS 1.1.0 CTL test as well as when you run the test using the jars provided by Ingo.

Along with  fixing the issue #44, we also made changes in the way we print the report when CTL tests run via Team engine console. Following are the changes that we made:

- We have added separators between the different tests, so that you can easily distinguish between 2 tests

- Added test statistics at the end of every tests i.e No of test that Passed, Failed and Skipped, Just the way the test statistic is shown when TestNG tests are run

- Also instead of showing the JAVA error logs in the consoles (as it doesn't make the result user friendly), we have removed the error logs console and added it in the result folder that is created. 

- At the end of every test we also tell the user where on their local directory will they find the Test results and if any errors occur we will tell them where the error log is created.

- We have also created a branch off Master branch in team engine git-hub where we have resolved issue #44 . Branch Name: feature-CTL-console-reporting