### PR TITLE
Adding ogc maven repository to root pom by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,27 +22,6 @@ for more information.
 * Execute the `mvn site` to generate project documentation;
 * A PDF document is created at the target/pdf directory.
 
-**Note**
-
-Some dependencies may not be not available in the central repository. To obtain 
-them, add the following remote repository to a profile in the Maven settings 
-file (${user.home}/.m2/settings.xml).
-
-    <profile>
-      <id>ogc.cite</id>
-      <!-- activate profile by default or explicitly -->
-      <repositories>
-        <repository>
-          <id>opengeospatial-cite</id>
-          <name>OGC CITE Repository</name>
-          <url>https://svn.opengeospatial.org/ogc-projects/cite/maven</url>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-        </repository>
-      </repositories>
-    </profile>
-
 ### Installing the tests
 
 To install the test read the PDF test look at the PDF created in the previous step

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,17 @@
     <module>teamengine-console</module>
   </modules>
 
+  <repositories>
+    <repository>
+      <id>opengeospatial-cite</id>
+      <name>OGC CITE Repository</name>
+      <url>https://svn.opengeospatial.org/ogc-projects/cite/maven</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
I didn't see any downside to adding the repo by adding the repository by default, rather than in a profile that has to be explicitly enabled. This way developers can just "mvn install' straight away. 
