### PR TITLE
Removing configuration for servlets that no longer exist

### DIFF
--- a/teamengine-web/src/main/webapp/WEB-INF/web.xml
+++ b/teamengine-web/src/main/webapp/WEB-INF/web.xml
@@ -42,10 +42,6 @@
     <servlet-class>com.occamlab.te.web.DeleteSessionServlet</servlet-class>
   </servlet>
   <servlet>
-    <servlet-name>renameSession</servlet-name>
-    <servlet-class>com.occamlab.te.web.RenameSessionServlet</servlet-class>
-  </servlet>
-  <servlet>
     <servlet-name>downloadLog</servlet-name>
     <servlet-class>com.occamlab.te.web.DownloadLogServlet</servlet-class>
   </servlet>	
@@ -76,16 +72,7 @@
       <param-name>mail.to</param-name>
       <param-value>approver@example.com</param-value>
     </init-param>
-  </servlet>	
-  <servlet>
-    <servlet-name>userProfile</servlet-name>
-    <servlet-class>com.occamlab.te.web.UserProfileServlet</servlet-class>
   </servlet>
-  <servlet>
-    <servlet-name>complianceTesting</servlet-name>
-    <servlet-class>com.occamlab.te.web.ComplianceTestingServlet</servlet-class>
-  </servlet>
-
   <servlet>
     <servlet-name>TestSuiteController</servlet-name>
     <servlet-class>com.sun.jersey.spi.container.servlet.ServletContainer</servlet-class>
@@ -136,10 +123,6 @@
     <url-pattern>/deleteSession</url-pattern>
   </servlet-mapping>
   <servlet-mapping>
-    <servlet-name>renameSession</servlet-name>
-    <url-pattern>/renameSession</url-pattern>
-  </servlet-mapping>
-  <servlet-mapping>
     <servlet-name>downloadLog</servlet-name>
     <url-pattern>/downloadLog</url-pattern>
   </servlet-mapping>
@@ -150,10 +133,6 @@
   <servlet-mapping>
     <servlet-name>emailLog</servlet-name>
     <url-pattern>/emailLog</url-pattern>
-  </servlet-mapping>
-  <servlet-mapping>
-    <servlet-name>userProfile</servlet-name>
-    <url-pattern>/userProfile</url-pattern>
   </servlet-mapping>
 
   <security-constraint>


### PR DESCRIPTION
There are a few servlets listed in web.xml that from what I can tell no longer exist. It seems Tomcat is lenient in this regard but Jetty (and I assume other containers) may not be. 
