### PR TITLE
Replacing property reference from web.xml with context listener.

### DIFF
--- a/teamengine-web/src/main/java/com/occamlab/te/web/TEServletContextListener.java
+++ b/teamengine-web/src/main/java/com/occamlab/te/web/TEServletContextListener.java
@@ -1,0 +1,27 @@
+package com.occamlab.te.web;
+
+import com.occamlab.te.SetupOptions;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import java.io.File;
+
+/**
+ * Context listener that initializes properties to be used application wide.
+ * <p>
+ * Currently sets the 'teConfigFile' parameter pointing to the main config.xml
+ * configuration file.
+ * </p>
+ */
+public class TEServletContextListener implements ServletContextListener {
+    @Override
+    public void contextInitialized(ServletContextEvent event) {
+        event.getServletContext().setAttribute("teConfigFile",
+            SetupOptions.getBaseConfigDirectory().getAbsolutePath() + File.separator + "config.xml");
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent event) {
+
+    }
+}

--- a/teamengine-web/src/main/webapp/WEB-INF/web.xml
+++ b/teamengine-web/src/main/webapp/WEB-INF/web.xml
@@ -10,14 +10,13 @@
   </description>
 
   <context-param>
-    <description xml:lang="en">Location of main configuration file.</description>
-    <param-name>teConfigFile</param-name>
-    <param-value>\${TE_BASE}\${file.separator}config.xml</param-value>
-  </context-param>
-  <context-param>
     <param-name>appVersion</param-name>
     <param-value>${project.version}</param-value>
   </context-param>
+
+  <listener>
+    <listener-class>com.occamlab.te.web.TEServletContextListener</listener-class>
+  </listener>
 
   <servlet>
     <servlet-name>test</servlet-name>

--- a/teamengine-web/src/main/webapp/welcome.jsp
+++ b/teamengine-web/src/main/webapp/welcome.jsp
@@ -2,7 +2,6 @@
 <%@ taglib prefix="x" uri="http://java.sun.com/jsp/jstl/xml"%>
 <%@ taglib prefix="f" uri="http://java.sun.com/jsp/jstl/functions"%>
 
-<c:set var="teConfigFile" value="${initParam.teConfigFile}" />
 <c:set var="backSlash" value="\\u005C" />
 <c:set var="configFilePath"
 	value="${f:replace(teConfigFile, backSlash, '/')}" />


### PR DESCRIPTION
Using property reference in web.xml is apparently not standard and only supported by Tomcat. This change should make the teConfigFile property supported on other containers. 
