### PR TITLE
Fix and test test results in console output

### DIFF
--- a/teamengine-core/src/main/java/com/occamlab/te/TECore.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/TECore.java
@@ -706,7 +706,7 @@ public class TECore implements Runnable {
         prevLog = oldPrevLog;
         indent = oldIndent;
         out.println(indent + "Test " + test.getName() + " "
-                + getResultDescription(verdict));
+                + getResultDescription(test.getResult()));
         if (LOGR.isLoggable(Level.FINE)) {
             String msg = String
                     .format("Executed test %s - Verdict: %s",


### PR DESCRIPTION
This fixes a small bug in test results printed to the output stream. It addressed the problem I noted in my [comment on a previous pull request](https://github.com/opengeospatial/teamengine/pull/67#issuecomment-65829022).

I also added some testing in TECoreTest.testNestedFailure to verify the output stream content.

With this patch, nested failures in teamengine are behaving correctly for me in a real world project.
