### PR TITLE
Update Maven plugins, testng-6.8.21, jersey-servlet-1.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-pdf-plugin</artifactId>
-        <version>1.2</version>
+        <version>1.3</version>
         <executions>
           <execution>
             <id>pdf</id>
@@ -163,7 +163,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.18</version>
+          <version>2.18.1</version>
           <configuration>
             <!-- Disable TestNG runner (enabled due to compile dependency) -->
             <testNGArtifactName>null:null</testNGArtifactName>
@@ -262,7 +262,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.7</version>
+        <version>2.8</version>
         <reportSets>
           <reportSet>
             <reports>

--- a/teamengine-core/pom.xml
+++ b/teamengine-core/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-core</artifactId>
-      <version>1.18.1</version>
+      <version>1.19</version>
       <type>jar</type>
     </dependency>
   </dependencies>

--- a/teamengine-spi/pom.xml
+++ b/teamengine-spi/pom.xml
@@ -32,9 +32,9 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.8.8</version>
+      <version>6.8.21</version>
       <exclusions>
-        <!-- alternative YAML syntax for specifying test suite -->
+        <!-- alternative YAML syntax for specifying a test suite -->
         <exclusion>
           <groupId>org.yaml</groupId>
           <artifactId>snakeyaml</artifactId>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-servlet</artifactId>
-      <version>1.18.1</version>
+      <version>1.19</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
-      <version>1.1</version>
+      <version>1.1.1</version>
       <type>jar</type>
     </dependency>
     <dependency>
@@ -87,6 +87,11 @@
       <artifactId>gson</artifactId>
       <version>2.2.2</version>
       <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>teamengine-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/teamengine-spi/src/main/java/com/occamlab/te/spi/jaxrs/resources/StoreRunResources.java
+++ b/teamengine-spi/src/main/java/com/occamlab/te/spi/jaxrs/resources/StoreRunResources.java
@@ -1,5 +1,6 @@
 package com.occamlab.te.spi.jaxrs.resources;
 
+import com.occamlab.te.SetupOptions;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -65,10 +66,7 @@ public class StoreRunResources {
     JSONObject jsonObjTestDetail = new JSONObject();
     JSONArray jsonArrTestDetail = new JSONArray();
     // Get TE_Base Directory path.
-    String basePath = System.getProperty(TE_BASE);
-    if (null == basePath) {
-      basePath = System.getenv(TE_BASE);
-    }
+    File basePath=SetupOptions.getBaseConfigDirectory();
     String pathAddress = basePath + "/users/" + userId + "/" + sessionID + "/test_data";
     int testCount = 1;
     int runTestId = 1;

--- a/teamengine-spi/src/main/java/com/occamlab/te/spi/jaxrs/resources/TestFinalResult.java
+++ b/teamengine-spi/src/main/java/com/occamlab/te/spi/jaxrs/resources/TestFinalResult.java
@@ -5,6 +5,7 @@
  */
 package com.occamlab.te.spi.jaxrs.resources;
 
+import com.occamlab.te.SetupOptions;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -46,10 +47,7 @@ public class TestFinalResult {
           @QueryParam("userID") String userId,
           @QueryParam("sessionID") String sessionID) throws FileNotFoundException, IOException {
 
-    String basePath = System.getProperty(TE_BASE);
-    if (null == basePath) {
-      basePath = System.getenv(TE_BASE);
-    }
+    File basePath=SetupOptions.getBaseConfigDirectory();
     String pathAddress = basePath + "/users/" + userId + "/" + sessionID + "/test_data";
 
     //Get the Final result from file which save after stop button click.

--- a/teamengine-spi/src/main/java/com/occamlab/te/spi/jaxrs/resources/TestMapResources.java
+++ b/teamengine-spi/src/main/java/com/occamlab/te/spi/jaxrs/resources/TestMapResources.java
@@ -1,5 +1,6 @@
 package com.occamlab.te.spi.jaxrs.resources;
 
+import com.occamlab.te.SetupOptions;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -57,10 +58,7 @@ public class TestMapResources {
           @QueryParam("userID") String userId,
           @QueryParam("sessionID") String sessionID) throws IOException, JSONException, ParserConfigurationException, SAXException {
 
-    String basePath = System.getProperty(TE_BASE);
-    if (null == basePath) {
-      basePath = System.getenv(TE_BASE);
-    }
+    File basePath=SetupOptions.getBaseConfigDirectory();
     String pathAddress = basePath + "/users/" + userId + "/" + sessionID + "/test_data";
 
     DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
@@ -110,11 +108,7 @@ public class TestMapResources {
   @Consumes({MediaType.TEXT_PLAIN})
   public void handlepost(@QueryParam("userID") String userId,
           @QueryParam("sessionID") String sessionID, String data) throws ParserConfigurationException, TransformerException, TransformerConfigurationException, FileNotFoundException, IOException {
-    String basePath = System.getProperty(TE_BASE);
-    if (null == basePath) {
-      basePath = System.getenv(TE_BASE);
-    }
-    
+    File basePath=SetupOptions.getBaseConfigDirectory();
 // Save data into file which comes through Rest end point.
     String pathAddress = basePath + "/users/" + userId + "/" + sessionID + "/test_data";
     File fulePath = new File(pathAddress, "/finalResult.txt");

--- a/teamengine-web/src/main/webapp/testControls.html
+++ b/teamengine-web/src/main/webapp/testControls.html
@@ -22,6 +22,16 @@
  <html>
 	<head>
 		<title>Test Controls</title>
+                <script type="text/javascript">
+                  function test(){
+                    if(null!==parent.window.frames["te_test_panel"].document.getElementById("stopTest")){
+                    var stopTestButton= parent.window.frames["te_test_panel"].document.getElementById("stopTest");
+                    stopTestButton.click();
+                  }else{
+                    parent.stop();
+                  }
+                  }
+                </script>
 	</head>
 	<body bgcolor="#000000" onload="if (window.innerHeight) document.images['banner'].height = window.innerHeight">
 		<img name="banner" style="position: absolute; top: 0px; left: 0px" src="images/banner.jpg" alt="TEAM Engine Banner"/>
@@ -33,7 +43,8 @@
 		</div>
 		<div style="position: absolute; right:20px; top:25px; background-color: white; padding: 3px; border-style: inset">
 			Test run in progress...<br/>
-			<a href="javascript:parent.stop()">Stop</a>
+			<!--<a href="javascript:parent.stop()">Stop</a>-->
+                        <input type="submit" value="Stop" onclick="test()"/>
 		</div>
 	</body>
 </html>


### PR DESCRIPTION
Follwing changes are done:
1. jersey-core(1.18.1) & jersey-servlet(1.19) version are not matching so updated jersey-core version to 1.19 in pom.xml of teamengine.
2. To fetch the TE_BASE path, updated the code to use "SetupOptions.getBaseConfigDirectory()" method of teamengine-core.
3. On AWS server it is not getting TE_BASE path, so we set TE_Base path on setenv.sh like that:
JAVA_OPTS="-Djava.awt.headless=true -XX:+UseG1GC -Dfile.encoding=UTF-8 **-DTE_BASE=/home/bitnami/TE_BASE** $JAVA_OPTS " 