### PR TITLE
Don't error on missing config.xml when checking recording info

### DIFF
--- a/teamengine-core/src/main/java/com/occamlab/te/SetupOptions.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/SetupOptions.java
@@ -97,27 +97,29 @@ public class SetupOptions {
   public static boolean recordingInfo(String testName) throws ParserConfigurationException, SAXException, IOException {
     TECore.rootTestName.clear();
     String path = getBaseConfigDirectory() + "/config.xml";
-    DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-    Document doc = db.parse(path);
-    NodeList nodeListForStandardTag = doc.getElementsByTagName("standard");
-    if (null!=nodeListForStandardTag && nodeListForStandardTag.getLength() > 0) {
-      for (int i = 0; i < nodeListForStandardTag.getLength(); i++) {
-        Element elementStandard = (Element) nodeListForStandardTag.item(i);
-        if (testName.equals(elementStandard.getElementsByTagName("local-name").item(0).getTextContent())) {
-          if (null!=elementStandard.getElementsByTagName("record").item(0)) {
-            System.setProperty("Record", "True");
-            NodeList rootTestNameArray=elementStandard.getElementsByTagName("test-name");
-            if (null!=rootTestNameArray && rootTestNameArray.getLength() > 0) {
-              for (int counter = 0; counter < rootTestNameArray.getLength(); counter++) {
-                Element rootTestName = (Element) rootTestNameArray.item(counter);
-                TECore.rootTestName.add(rootTestName.getTextContent());
+    if (new File(path).exists()) {
+        DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Document doc = db.parse(path);
+        NodeList nodeListForStandardTag = doc.getElementsByTagName("standard");
+        if (null!=nodeListForStandardTag && nodeListForStandardTag.getLength() > 0) {
+          for (int i = 0; i < nodeListForStandardTag.getLength(); i++) {
+            Element elementStandard = (Element) nodeListForStandardTag.item(i);
+            if (testName.equals(elementStandard.getElementsByTagName("local-name").item(0).getTextContent())) {
+              if (null!=elementStandard.getElementsByTagName("record").item(0)) {
+                System.setProperty("Record", "True");
+                NodeList rootTestNameArray=elementStandard.getElementsByTagName("test-name");
+                if (null!=rootTestNameArray && rootTestNameArray.getLength() > 0) {
+                  for (int counter = 0; counter < rootTestNameArray.getLength(); counter++) {
+                    Element rootTestName = (Element) rootTestNameArray.item(counter);
+                    TECore.rootTestName.add(rootTestName.getTextContent());
+                  }
+                }
+                return true;
               }
             }
-            return true;
+    
           }
         }
-
-      }
     }
     System.setProperty("Record", "False");
     return false;

--- a/teamengine-core/src/test/java/com/occamlab/te/SetupOptionsTest.java
+++ b/teamengine-core/src/test/java/com/occamlab/te/SetupOptionsTest.java
@@ -1,12 +1,18 @@
 package com.occamlab.te;
 
+import static org.junit.Assert.assertFalse;
+
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
+
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.xml.sax.SAXException;
 
 public class SetupOptionsTest {
 
@@ -66,4 +72,10 @@ public class SetupOptionsTest {
         Assert.assertEquals("Unexpected size", 0, sources.size());
     }
 
+    @Test
+    public void testRecordingInfoWithoutConfig() throws ParserConfigurationException, SAXException, IOException {
+        assertFalse(new File(SetupOptions.getBaseConfigDirectory(), "config.xml").exists());
+        //checking recording info should work even if config.xml doesn't exist
+        SetupOptions.recordingInfo("foo");
+    }
 }


### PR DESCRIPTION
Should fix #83. If config.xml doesn't exist, just let recordingInfo be false. Included a test case.