### PR TITLE
Add XmlValidatingParser.validateSingleResult

### DIFF
--- a/teamengine-core/src/main/java/com/occamlab/te/parsers/XMLValidatingParser.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/parsers/XMLValidatingParser.java
@@ -315,7 +315,7 @@ public class XMLValidatingParser {
         return (parsedDoc != null);
     }
 
-    public NodeList validate(Document doc, Document instruction)
+    private XmlErrorHandler processValidation(Document doc, Document instruction)
             throws Exception {
         if (doc == null || doc.getDocumentElement() == null) {
             throw new NullPointerException("Input document is null.");
@@ -326,12 +326,20 @@ public class XMLValidatingParser {
         dtds.addAll(dtdList);
         loadSchemaLists(instruction, schemas, dtds);
 
-        NodeList errorStrings = null;
         XmlErrorHandler err = new XmlErrorHandler();
         validateAgainstXMLSchemaList(doc, schemas, err);
         validateAgainstDTDList(doc, dtds, err);
-        errorStrings = err.toNodeList();
-        return errorStrings;
+        return err;
+    }
+    
+    public NodeList validate(Document doc, Document instruction)
+            throws Exception {
+        return processValidation(doc, instruction).toNodeList();
+    }
+
+    public Element validateSingleResult(Document doc, Document instruction)
+            throws Exception {
+        return processValidation(doc, instruction).toRootElement();
     }
 
     /**

--- a/teamengine-core/src/main/java/com/occamlab/te/parsers/XmlErrorHandler.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/parsers/XmlErrorHandler.java
@@ -158,13 +158,14 @@ public class XmlErrorHandler implements ErrorHandler {
     }
 
     /**
-     * Returns validation errors in a NodeList (needed for CTL processing). Each
-     * item in the list is an {@code <error>} element containing an error
-     * message as text content.
+     * Returns validation errors in a root container node.
+     * The root container ({@code <errors>}) contains a list
+     * of {@code <error>} elements containing error
+     * messages as text content.
      * 
-     * @return a list of errors in a NodeList.
+     * @return Root element containing list of errors
      */
-    public NodeList toNodeList() {
+    public Element toRootElement() {
         Document doc = null;
         try {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -184,7 +185,18 @@ public class XmlErrorHandler implements ErrorHandler {
             elem.setTextContent(err.getMessage());
             root.appendChild(elem);
         }
-        return doc.getElementsByTagName("error");
+        return root;
+    }
+
+    /**
+     * Returns validation errors in a NodeList (needed for CTL processing). Each
+     * item in the list is an {@code <error>} element containing an error
+     * message as text content.
+     * 
+     * @return a list of errors in a NodeList.
+     */
+    public NodeList toNodeList() {
+        return toRootElement().getElementsByTagName("error");
     }
 
     /**


### PR DESCRIPTION
This pull request does some minor refactoring in XmlValidatingParser and XmlErrorHandler to add a XmlValidatingParser.validateSingleResult method. XmlValidatingParser.validate returns errors as a NodeList, but when calling that method using ctl:java only the first element/error in the NodeList is returned. This appears to be because of behaviors in the Saxon library (only returning next() on an iterator when a method's return type isn't detected to be a list/sequence/array, e.g. Object, and locking results to single result `process` mode instead of `iterate`).

I spent several hours trying to figure out a workaround, and the best/simplest solution I could come up with was to add another method to XmlValidatingParser which returns the `errors` wrapped in a single root `error` node. This doesn't solve any problems for the other validating parser classes, but it's simple and not intrusive.