### PR TITLE
Multiple code improvements - squid:S1192, squid:S1488, squid:S1213

### DIFF
--- a/teamengine-spi/src/main/java/com/occamlab/te/spi/jaxrs/resources/TestRunResource.java
+++ b/teamengine-spi/src/main/java/com/occamlab/te/spi/jaxrs/resources/TestRunResource.java
@@ -47,6 +47,9 @@ import com.sun.jersey.multipart.FormDataParam;
 public class TestRunResource {
 
     private static final Logger LOGR = Logger.getLogger(TestRunResource.class.getPackage().getName());
+    public static final String TEST_RUN_ARGUMENTS = "Test run arguments - ";
+    public static final String ENTITY_MEDIA_TYPE = "Entity media type: ";
+    public static final String FILE_LOCATION = "File location: ";
     @Context
     private UriInfo reqUriInfo;
 
@@ -68,13 +71,12 @@ public class TestRunResource {
     public Source handleGet(@PathParam("etsCode") String etsCode, @PathParam("etsVersion") String etsVersion) {
         MultivaluedMap<String, String> params = this.reqUriInfo.getQueryParameters();
         if (LOGR.isLoggable(Level.FINE)) {
-            StringBuilder msg = new StringBuilder("Test run arguments - ");
+            StringBuilder msg = new StringBuilder(TEST_RUN_ARGUMENTS);
             msg.append(etsCode).append("/").append(etsVersion).append("\n");
             msg.append(params.toString());
             LOGR.fine(msg.toString());
         }
-        Source results = executeTestRun(etsCode, etsVersion, params);
-        return results;
+        return executeTestRun(etsCode, etsVersion, params);
     }
 
     /**
@@ -99,16 +101,15 @@ public class TestRunResource {
             throw new WebApplicationException(400);
         }
         if (LOGR.isLoggable(Level.FINE)) {
-            StringBuilder msg = new StringBuilder("Test run arguments - ");
+            StringBuilder msg = new StringBuilder(TEST_RUN_ARGUMENTS);
             msg.append(etsCode).append("/").append(etsVersion).append("\n");
-            msg.append("Entity media type: " + this.headers.getMediaType());
-            msg.append("File location: " + entityBody.getAbsolutePath());
+            msg.append(ENTITY_MEDIA_TYPE + this.headers.getMediaType());
+            msg.append(FILE_LOCATION + entityBody.getAbsolutePath());
             LOGR.fine(msg.toString());
         }
         Map<String, java.util.List<String>> args = new HashMap<String, List<String>>();
         args.put("iut", Arrays.asList(entityBody.toURI().toString()));
-        Source results = executeTestRun(etsCode, etsVersion, args);
-        return results;
+        return executeTestRun(etsCode, etsVersion, args);
     }
 
     /**
@@ -150,10 +151,10 @@ public class TestRunResource {
             throw new WebApplicationException(400);
         }
         if (LOGR.isLoggable(Level.FINE)) {
-            StringBuilder msg = new StringBuilder("Test run arguments - ");
+            StringBuilder msg = new StringBuilder(TEST_RUN_ARGUMENTS);
             msg.append(etsCode).append("/").append(etsVersion).append("\n");
-            msg.append("Entity media type: " + this.headers.getMediaType());
-            msg.append("File location: " + entityBody.getAbsolutePath());
+            msg.append(ENTITY_MEDIA_TYPE + this.headers.getMediaType());
+            msg.append(FILE_LOCATION + entityBody.getAbsolutePath());
             LOGR.fine(msg.toString());
         }
         args.put("iut", Arrays.asList(entityBody.toURI().toString()));
@@ -162,16 +163,15 @@ public class TestRunResource {
                 throw new WebApplicationException(400);
             }
             if (LOGR.isLoggable(Level.FINE)) {
-                StringBuilder msg = new StringBuilder("Test run arguments - ");
+                StringBuilder msg = new StringBuilder(TEST_RUN_ARGUMENTS);
                 msg.append(etsCode).append("/").append(etsVersion).append("\n");
-                msg.append("Entity media type: " + this.headers.getMediaType());
-                msg.append("File location: " + schBody.getAbsolutePath());
+                msg.append(ENTITY_MEDIA_TYPE + this.headers.getMediaType());
+                msg.append(FILE_LOCATION + schBody.getAbsolutePath());
                 LOGR.fine(msg.toString());
             }
             args.put("sch", Arrays.asList(schBody.toURI().toString()));
         }
-        Source results = executeTestRun(etsCode, etsVersion, args);
-        return results;
+        return executeTestRun(etsCode, etsVersion, args);
     }
 
     /**

--- a/teamengine-web/src/main/java/com/occamlab/te/web/CoverageMonitor.java
+++ b/teamengine-web/src/main/java/com/occamlab/te/web/CoverageMonitor.java
@@ -63,24 +63,13 @@ public class CoverageMonitor {
             .getPackage().getName());
     private static final Map<URI, String> ICS_MAP = createICSMap();
 
-    private static Map<URI, String> createICSMap() {
-        HashMap<URI, String> icsMap = new HashMap<URI, String>();
-        icsMap.put(URI.create("urn:wms_client_test_suite/GetCapabilities"),
-                "WMS-GetCapabilities.xml");
-        icsMap.put(URI.create("urn:wms_client_test_suite/GetMap"),
-                "WMS-GetMap.xml");
-        icsMap.put(URI.create("urn:wms_client_test_suite/GetFeatureInfo"),
-                "WMS-GetFeatureInfo.xml");
-        return icsMap;
-    }
-
     private URI requestId;
     private Document coverageDoc;
     private File testSessionDir;
 
     /**
      * Creates a CoverageMonitor for a given service request.
-     * 
+     *
      * @param uri
      *            A URI value that identifies a service request message.
      */
@@ -96,6 +85,17 @@ public class CoverageMonitor {
             LOGR.warning(e.getMessage());
         }
         LOGR.config("Created coverage monitor using ICS at " + icsPath);
+    }
+
+    private static Map<URI, String> createICSMap() {
+        HashMap<URI, String> icsMap = new HashMap<URI, String>();
+        icsMap.put(URI.create("urn:wms_client_test_suite/GetCapabilities"),
+                "WMS-GetCapabilities.xml");
+        icsMap.put(URI.create("urn:wms_client_test_suite/GetMap"),
+                "WMS-GetMap.xml");
+        icsMap.put(URI.create("urn:wms_client_test_suite/GetFeatureInfo"),
+                "WMS-GetFeatureInfo.xml");
+        return icsMap;
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 - String literals should not be duplicated.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
