### PR TITLE
Multiple code improvements - squid:S2275, squid:S1197, squid:S1213, squid:S1066

### DIFF
--- a/teamengine-core/src/main/java/com/occamlab/te/parsers/HTTPParser.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/parsers/HTTPParser.java
@@ -211,7 +211,7 @@ public class HTTPParser {
             Element status = doc.createElement("status");
             String status_line = uc.getHeaderField(0);
             if (status_line != null) {
-                String status_array[] = status_line.split("\\s");
+                String[] status_array = status_line.split("\\s");
                 if (status_array.length > 0) {
                     status.setAttribute("protocol", status_array[0]);
                 }
@@ -295,7 +295,7 @@ public class HTTPParser {
             // use TECore to invoke any chained (subsidiary) parsers
             if (LOGR.isLoggable(Level.FINER)) {
                 String msg = String.format(
-                        "Calling subsidiary parser for resource at %s:\n%s",
+                        "Calling subsidiary parser for resource at %s:%n%s",
                         uc.getURL(), DomUtils.serializeNode(parser));
                 LOGR.finer(msg);
             }

--- a/teamengine-core/src/main/java/com/occamlab/te/parsers/ImageParser.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/parsers/ImageParser.java
@@ -172,7 +172,7 @@ public class ImageParser {
         int maxx = minx + raster.getWidth();
         int miny = raster.getMinY();
         int maxy = miny + raster.getHeight();
-        int bands[][] = new int[bandIndexes.length][raster.getWidth()];
+        int[][] bands = new int[bandIndexes.length][raster.getWidth()];
         for (int y = miny; y < maxy; y++) {
             for (int i = 0; i < bandIndexes.length; i++) {
                 raster.getSamples(minx, y, maxx, 1, bandIndexes[i], bands[i]);
@@ -240,11 +240,9 @@ public class ImageParser {
                     } else {
                         HashMap<Object, Object> sampleMap = (HashMap<Object, Object>) bandMap
                                 .get(band);
-                        if (sampleMap == null) {
-                            if (!bandMap.containsKey(band)) {
-                                sampleMap = new HashMap<Object, Object>();
-                                bandMap.put(band, sampleMap);
-                            }
+                        if (sampleMap == null && !bandMap.containsKey(band)) {
+                            sampleMap = new HashMap<Object, Object>();
+                            bandMap.put(band, sampleMap);
                         }
                         sampleMap.put(Integer.decode(sample), new Integer(0));
                     }
@@ -260,7 +258,7 @@ public class ImageParser {
         Iterator bandIt = bandMap.keySet().iterator();
         while (bandIt.hasNext()) {
             String band_str = (String) bandIt.next();
-            int band_indexes[];
+            int[] band_indexes;
             if (buffimage.getType() == BufferedImage.TYPE_BYTE_BINARY
                     || buffimage.getType() == BufferedImage.TYPE_BYTE_GRAY) {
                 band_indexes = new int[1];
@@ -292,7 +290,7 @@ public class ImageParser {
             int maxx = minx + raster.getWidth();
             int miny = raster.getMinY();
             int maxy = miny + raster.getHeight();
-            int bands[][] = new int[band_indexes.length][raster.getWidth()];
+            int[][] bands = new int[band_indexes.length][raster.getWidth()];
 
             for (int y = miny; y < maxy; y++) {
                 for (int i = 0; i < band_indexes.length; i++) {
@@ -325,64 +323,59 @@ public class ImageParser {
 
         Node node = nodes.item(0);
         while (node != null) {
-            if (node.getNodeType() == Node.ELEMENT_NODE) {
-                if (node.getLocalName().equals("count")) {
-                    String band = ((Element) node).getAttribute("bands");
-                    String sample = ((Element) node).getAttribute("sample");
-                    HashMap sampleMap = (HashMap) bandMap.get(band);
-                    Document doc = node.getOwnerDocument();
-                    if (sample.equals("all")) {
-                        Node parent = node.getParentNode();
-                        Node prevSibling = node.getPreviousSibling();
-                        Iterator sampleIt = sampleMap.keySet().iterator();
-                        Element countnode = null;
-                        int digits;
-                        String prefix;
-                        switch (buffimage.getType()) {
-                        case BufferedImage.TYPE_BYTE_BINARY:
-                            digits = 1;
-                            prefix = "";
-                            break;
-                        case BufferedImage.TYPE_BYTE_GRAY:
-                            digits = 2;
-                            prefix = "0x";
-                            break;
-                        default:
-                            prefix = "0x";
-                            digits = band.length() * 2;
-                        }
-                        while (sampleIt.hasNext()) {
-                            countnode = doc.createElementNS(
-                                    node.getNamespaceURI(), "count");
-                            Integer sampleInt = (Integer) sampleIt.next();
-                            Integer count = (Integer) sampleMap.get(sampleInt);
-                            if (band.length() > 0) {
-                                countnode.setAttribute("bands", band);
-                            }
-                            countnode.setAttribute("sample", prefix
-                                    + HexString(sampleInt.intValue(), digits));
-                            Node textnode = doc
-                                    .createTextNode(count.toString());
-                            countnode.appendChild(textnode);
-                            parent.insertBefore(countnode, node);
-                            if (sampleIt.hasNext()) {
-                                if (prevSibling != null
-                                        && prevSibling.getNodeType() == Node.TEXT_NODE) {
-                                    parent.insertBefore(
-                                            prevSibling.cloneNode(false), node);
-                                }
-                            }
-                        }
-                        parent.removeChild(node);
-                        node = countnode;
-                    } else {
-                        Integer count = (Integer) sampleMap.get(Integer
-                                .decode(sample));
-                        if (count == null)
-                            count = new Integer(0);
-                        Node textnode = doc.createTextNode(count.toString());
-                        node.appendChild(textnode);
+            if (node.getNodeType() == Node.ELEMENT_NODE && node.getLocalName().equals("count")) {
+                String band = ((Element) node).getAttribute("bands");
+                String sample = ((Element) node).getAttribute("sample");
+                HashMap sampleMap = (HashMap) bandMap.get(band);
+                Document doc = node.getOwnerDocument();
+                if (sample.equals("all")) {
+                    Node parent = node.getParentNode();
+                    Node prevSibling = node.getPreviousSibling();
+                    Iterator sampleIt = sampleMap.keySet().iterator();
+                    Element countnode = null;
+                    int digits;
+                    String prefix;
+                    switch (buffimage.getType()) {
+                    case BufferedImage.TYPE_BYTE_BINARY:
+                        digits = 1;
+                        prefix = "";
+                        break;
+                    case BufferedImage.TYPE_BYTE_GRAY:
+                        digits = 2;
+                        prefix = "0x";
+                        break;
+                    default:
+                        prefix = "0x";
+                        digits = band.length() * 2;
                     }
+                    while (sampleIt.hasNext()) {
+                        countnode = doc.createElementNS(
+                                node.getNamespaceURI(), "count");
+                        Integer sampleInt = (Integer) sampleIt.next();
+                        Integer count = (Integer) sampleMap.get(sampleInt);
+                        if (band.length() > 0) {
+                            countnode.setAttribute("bands", band);
+                        }
+                        countnode.setAttribute("sample", prefix
+                                + HexString(sampleInt.intValue(), digits));
+                        Node textnode = doc
+                                .createTextNode(count.toString());
+                        countnode.appendChild(textnode);
+                        parent.insertBefore(countnode, node);
+                        if (sampleIt.hasNext() && prevSibling != null && prevSibling.getNodeType() == Node.TEXT_NODE) {
+                            parent.insertBefore(
+                                    prevSibling.cloneNode(false), node);
+                        }
+                    }
+                    parent.removeChild(node);
+                    node = countnode;
+                } else {
+                    Integer count = (Integer) sampleMap.get(Integer
+                            .decode(sample));
+                    if (count == null)
+                        count = new Integer(0);
+                    Node textnode = doc.createTextNode(count.toString());
+                    node.appendChild(textnode);
                 }
             }
             node = node.getNextSibling();
@@ -561,7 +554,7 @@ public class ImageParser {
             doc = parse(is, instruction, logger);
         } catch (Exception e) {
             String msg = String.format(
-                    "Failed to parse %s resource from %s \n %s",
+                    "Failed to parse %s resource from %s %n %s",
                     uc.getContentType(), uc.getURL(), e.getMessage());
             jlogger.warning(msg);
         } finally {

--- a/teamengine-core/src/main/java/com/occamlab/te/parsers/SchematronValidatingParser.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/parsers/SchematronValidatingParser.java
@@ -411,7 +411,7 @@ public class SchematronValidatingParser {
         NodeList errList = errHandler.toNodeList();
         if (LOGR.isLoggable(Level.FINER)) {
             LOGR.finer(String.format(
-                    "Found %d Schematron rule violation(s):\n %s",
+                    "Found %d Schematron rule violation(s):%n %s",
                     errList.getLength(), errHandler.toString()));
         }
         return errList;

--- a/teamengine-core/src/main/java/com/occamlab/te/parsers/XSLTransformationParser.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/parsers/XSLTransformationParser.java
@@ -41,6 +41,29 @@ public class XSLTransformationParser {
     Boolean defaultIgnoreErrors;
     Boolean defaultIgnoreWarnings;
 
+    public XSLTransformationParser() throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        db = dbf.newDocumentBuilder();
+        tf = TransformerFactory.newInstance();
+        defaultProperties = new HashMap<String, String>();
+        defaultParams = new HashMap<String, String>();
+        defaultIgnoreErrors = new Boolean(false);
+        defaultIgnoreWarnings = new Boolean(true);
+    }
+
+    public XSLTransformationParser(Node node) throws Exception {
+        super();
+        defaultTemplates = parseInstruction(DomUtils.getElement(node),
+                defaultProperties, defaultParams, defaultIgnoreErrors,
+                defaultIgnoreWarnings);
+    }
+
+    public XSLTransformationParser(String reftype, String ref) throws Exception {
+        super();
+        defaultTemplates = tf.newTemplates(getSource(reftype, ref));
+    }
+
     private Source getSource(String reftype, String ref) throws Exception {
         if (reftype.equals("url")) {
             URL url = new URL(ref);
@@ -97,29 +120,6 @@ public class XSLTransformationParser {
         return templates;
     }
 
-    public XSLTransformationParser() throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setNamespaceAware(true);
-        db = dbf.newDocumentBuilder();
-        tf = TransformerFactory.newInstance();
-        defaultProperties = new HashMap<String, String>();
-        defaultParams = new HashMap<String, String>();
-        defaultIgnoreErrors = new Boolean(false);
-        defaultIgnoreWarnings = new Boolean(true);
-    }
-
-    public XSLTransformationParser(Node node) throws Exception {
-        super();
-        defaultTemplates = parseInstruction(DomUtils.getElement(node),
-                defaultProperties, defaultParams, defaultIgnoreErrors,
-                defaultIgnoreWarnings);
-    }
-
-    public XSLTransformationParser(String reftype, String ref) throws Exception {
-        super();
-        defaultTemplates = tf.newTemplates(getSource(reftype, ref));
-    }
-
     public Document parse(URLConnection uc, Element instruction,
             PrintWriter logger) throws Exception {
         HashMap<String, String> properties = new HashMap<String, String>();
@@ -153,7 +153,7 @@ public class XSLTransformationParser {
         try {
             if (LOGR.isLoggable(Level.FINER)) {
                 String msg = String
-                        .format("Attempting to transform source from %s using instruction set:\n %s",
+                        .format("Attempting to transform source from %s using instruction set:%n %s",
                                 uc.getURL(),
                                 DomUtils.serializeNode(instruction));
                 LOGR.finer(msg);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1066 - Collapsible "if" statements should be merged.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2275
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1066
Please let me know if you have any questions.
George Kankava
