### PR TITLE
Adding support for building docker image with TEAM engine installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 .classpath
 .settings/
 
+# IntelliJ IDEA config
+.idea
+*.iml
+
 # Maven output
 target/
 pom.xml.releaseBackup

--- a/teamengine-virtualization/README.md
+++ b/teamengine-virtualization/README.md
@@ -1,0 +1,65 @@
+# Running OGC TEAM Engine with ETS for WFS 2.0 on Docker
+
+This module provides a Dockerfile for building a Docker image with OGC TEAM Engine and ets-wfs20, version 1.22
+pre-installed.
+
+## Prerequisites
+
+### Install Docker
+
+Check the official [Docker documentation](https://docs.docker.com/engine/) for information how to
+  install Docker on your operating system. And then install Docker and supporting tools.
+
+### Dependencies 
+
+You may build the following projects first:
+
+#### Build ets-resources:
+    
+    % git clone https://github.com/opengeospatial/ets-resources.git
+    % cd ets-resources
+    % git checkout tags/16.02.23
+    % mvn clean install
+    
+#### Build the ETS for WFS 2.0:
+    
+    % git clone https://github.com/opengeospatial/ets-wfs20.git
+    % cd ets-wfs20
+    % git checkout tags/1.22
+    % mvn clean install
+
+#### Build the TEAM Engine:
+    
+    % git clone https://github.com/opengeospatial/teamengine.git
+    % cd teamengine
+    % git checkout tags/4.6
+    % mvn clean install -Dets-resources-version=16.02.23 -Pogc.cite
+
+## Build the Docker image
+The Dockerfile is located in the ```teamengine/teamengine-virtualization/src/main/config/docker``` directory. 
+To build the Docker image run in directory ```teamengine/teamengine-virtualization/``` the Maven goals:
+
+    % mvn clean package docker:build
+
+This will build a new docker image from scratch. It may take a while the first time since Docker will download some
+base images from [docker hub](https://hub.docker.com).
+
+Check if the docker image has been built successfully with:
+
+    % docker images
+
+## Running TEAM Engine inside a Docker container 
+The following docker command starts the TEAM Engine inside the Docker container with the name ```teamengine``` on port 8088
+with the previously built Docker image named ```opengis/teamengine```:
+
+    % docker run -p 8088:8080 --name teamengine --rm opengis/teamengine
+
+## Accessing the TEAM Engine web interface
+Use a browser of your choice and open the URL:
+
+http://container-ip:8088/teamengine
+
+If your are running Docker on Windows or OS X with docker-machine check the IP with ```docker-machine ip```.
+On Linux it is most likely localhost/127.0.0.1 on Windows and macOS it might be a IP like:
+
+http://192.168.99.100:8088/teamengine

--- a/teamengine-virtualization/pom.xml
+++ b/teamengine-virtualization/pom.xml
@@ -43,6 +43,96 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>false</overWriteSnapshots>
+              <overWriteIfNewer>true</overWriteIfNewer>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.4.10</version>
+        <configuration>
+          <imageName>${docker.image.prefix}/${docker.image.name}</imageName>
+          <dockerDirectory>${project.basedir}/src/main/config/docker</dockerDirectory>
+          <resources>
+            <resource>
+              <targetPath>/</targetPath>
+              <directory>${project.build.directory}</directory>
+              <include>teamengine-web-*.war</include>
+            </resource>
+            <resource>
+              <targetPath>/</targetPath>
+              <directory>${project.build.directory}</directory>
+              <includes>
+                <include>**/*.zip</include>
+              </includes>
+              <excludes>
+                <exclude>**/*.class</exclude>
+              </excludes>
+            </resource>
+          </resources>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.opengis.cite.teamengine</groupId>
+      <artifactId>teamengine-web</artifactId>
+      <version>${teamengine.version}</version>
+      <type>war</type>
+    </dependency>
+    <dependency>
+      <groupId>org.opengis.cite.teamengine</groupId>
+      <artifactId>teamengine-web</artifactId>
+      <version>${teamengine.version}</version>
+      <classifier>common-libs</classifier>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>org.opengis.cite.teamengine</groupId>
+      <artifactId>teamengine-console</artifactId>
+      <version>${teamengine.version}</version>
+      <classifier>base</classifier>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>org.opengis.cite</groupId>
+      <artifactId>ets-wfs20</artifactId>
+      <version>${ets-wfs20.version}</version>
+      <classifier>ctl</classifier>
+      <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>org.opengis.cite</groupId>
+      <artifactId>ets-wfs20</artifactId>
+      <version>${ets-wfs20.version}</version>
+      <classifier>deps</classifier>
+      <type>zip</type>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <docker.image.prefix>opengis</docker.image.prefix>
+    <docker.image.name>teamengine</docker.image.name>
+    <ets-wfs20.version>1.22</ets-wfs20.version>
+    <teamengine.version>${project.version}</teamengine.version>
+  </properties>
 </project>

--- a/teamengine-virtualization/src/main/config/docker/Dockerfile
+++ b/teamengine-virtualization/src/main/config/docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM tomcat:7.0-jre8
+
+MAINTAINER Torsten Friebe <friebe@lat-lon.de>
+
+# set TEAM engine version
+ENV TEAMENGINE_VERSION 4.8-SNAPSHOT
+
+# add TEAM engine webapp
+ADD teamengine-web-${TEAMENGINE_VERSION}.war /root/
+RUN cd /root/ && unzip -q teamengine-web-${TEAMENGINE_VERSION}.war -d /usr/local/tomcat/webapps/teamengine
+
+# add common libs
+ADD teamengine-web-${TEAMENGINE_VERSION}-common-libs.zip /root/
+RUN cd /root/ && unzip -q teamengine-web-${TEAMENGINE_VERSION}-common-libs.zip -d /usr/local/tomcat/lib
+
+# add TEAM engine console
+ADD teamengine-console-${TEAMENGINE_VERSION}-base.zip /root/
+RUN cd /root/ && unzip -q teamengine-console-${TEAMENGINE_VERSION}-base.zip -d /root/te_base
+
+# set TE_BASE
+ENV JAVA_OPTS="-Xms1024m -Xmx2048m -DTE_BASE=/root/te_base"
+
+# set WFS 2.0 ETS version
+ENV ETS_WFS_20_VERSION 1.22
+
+# add ETS for WFS 2.0
+ADD ets-wfs20-${ETS_WFS_20_VERSION}-ctl.zip /root/
+RUN cd /root/ && unzip -q ets-wfs20-${ETS_WFS_20_VERSION}-ctl.zip -d /root/te_base/scripts
+ADD ets-wfs20-${ETS_WFS_20_VERSION}-deps.zip /root/
+RUN cd /root/ && unzip -q -o ets-wfs20-${ETS_WFS_20_VERSION}-deps.zip -d /usr/local/tomcat/webapps/teamengine/WEB-INF/lib
+
+# run tomcat
+CMD ["catalina.sh", "run"]


### PR DESCRIPTION
This PR contains a Dockerfile for building a Docker image with OGC TEAM Engine using the spotify ```docker-maven-plugin```.

To build the Docker image run in directory ```teamengine/teamengine-virtualization/``` the Maven goals:

    % mvn clean package docker:build

To run TEAM Engine inside the Docker container with the name ```teamengine``` on port 8088
with the previously built Docker image named ```opengis/teamengine``` execute:

    % docker run -p 8088:8080 --name teamengine --rm opengis/teamengine
