### PR TITLE
Fixed NullPointerException if content type is null

### DIFF
--- a/teamengine-core/src/main/java/com/occamlab/te/TECore.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/TECore.java
@@ -1979,7 +1979,7 @@ public class TECore implements Runnable {
       String contentType = uc.getContentType();
       try {
         is = URLConnectionUtils.getInputStream(uc);
-        if (contentType.contains("xml")) { // a crude check
+        if (contentType != null && contentType.contains("xml")) { // a crude check
           idt.transform(new StreamSource(is),
                   new DOMResult(content_e));
         } else {


### PR DESCRIPTION
A NullPointerException can occur if the content type of a response is null.

For example, the error can be seen if service [1] is tested with the ets-wmts10.

This pull request introduces a null check to prevent a possible NullPointerException.

[1] http://cite.deegree.org/deegree-webservices-3.4-RC1/services/wmts100?service=WMTS&request=GetCapabilities