### PR TITLE
Fixes for path manipulation vulnerability.

### DIFF
--- a/teamengine-core/src/main/java/com/occamlab/te/ListSuites.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/ListSuites.java
@@ -4,10 +4,13 @@ import java.io.File;
 
 import com.occamlab.te.index.Index;
 import com.occamlab.te.index.SuiteEntry;
+import com.occamlab.te.util.ValidPath;  // Fortify addition
 
 /**
  * Provides utility methods for managing a collection of CTL test suites.
  * 
+ *  Contributor(s): 
+ *  	C. Heazel (WiSC): Added Fortify adjudication changes
  */
 public class ListSuites {
 
@@ -20,7 +23,10 @@ public class ListSuites {
                 File scriptsDir = new File(
                         SetupOptions.getBaseConfigDirectory(), "scripts");
                 File f = new File(scriptsDir, args[i].substring(8));
-                if (f.exists()) {
+                // FORTIFY MOD: don't allow invalid path names
+                ValidPath vpath = new ValidPath();
+                vpath.addElement(f.getAbsolutePath());
+                if (vpath.isValid() && f.exists()) {
                     setupOpts.addSource(f);
                 } else {
                     System.out.println("Error: Can't find CTL script(s) at "

--- a/teamengine-core/src/main/java/com/occamlab/te/RecordTestResult.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/RecordTestResult.java
@@ -12,6 +12,8 @@ import static com.occamlab.te.TECore.getResultDescription;
 import com.occamlab.te.index.SuiteEntry;
 import com.occamlab.te.index.TestEntry;
 import com.occamlab.te.util.Constants;
+import com.occamlab.te.util.ValidPath;  // FORTIFY Mod
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -139,6 +141,12 @@ public class RecordTestResult {
         idTransform.setOutputProperty(OutputKeys.ENCODING, UT_F8);
         // Declare document is well indented
         idTransform.setOutputProperty(OutputKeys.INDENT, YES);
+        // FORTIFY Mod: validate the file path
+        ValidPath vpath = new ValidPath();
+        vpath.addElement(dirPath.toString());
+        vpath.addElement(Constants.tmp_File);
+        if(!vpath.isValid())
+        	throw new Exception("FORTIFY Path Error: dirPath = " + dirPath.toString() + " tmp_File = " + Constants.tmp_File);
         OutputStream report_logs = new FileOutputStream(new File(dirPath + Constants.tmp_File));
         Result output = new StreamResult(report_logs);
         //transform the output in xml.
@@ -187,6 +195,12 @@ public class RecordTestResult {
         idTransform.setOutputProperty(OutputKeys.ENCODING, UT_F8);
         // Declare document is well indented
         idTransform.setOutputProperty(OutputKeys.INDENT, YES);
+        // FORTIFY Mod: validate the file path
+        ValidPath vpath = new ValidPath();
+        vpath.addElement(dirPath.toString());
+        vpath.addElement(Constants.tmp_File);
+        if(!vpath.isValid())
+        	throw new Exception("FORTIFY Path Error: dirPath = " + dirPath.toString() + " tmp_File = " + Constants.tmp_File);
         OutputStream report_logs = new FileOutputStream(new File(dirPath + Constants.tmp_File));
         Result output = new StreamResult(report_logs);
         //transform the output in xml.
@@ -276,6 +290,12 @@ public class RecordTestResult {
         JSONObject objBeforeTest = new JSONObject();
         objBeforeTest.put(NAME, test.getName());
         objBeforeTest.put(RESULT, "");
+        // FORTIFY Mod: validate the file path
+        ValidPath vpath = new ValidPath();
+        vpath.addElement(dirPath.toString());
+        vpath.addElement(Constants.TEST_RESULTTXT);
+        if(!vpath.isValid())
+        	throw new Exception("FORTIFY Path Error: dirPath = " + dirPath.toString() + " TEST_RESULTTXT = " + Constants.TEST_RESULTTXT);
         // write the data into file in form of json
         OutputStreamWriter writerBefore = new OutputStreamWriter(
                 new FileOutputStream(dirPath + Constants.TEST_RESULTTXT, true), UT_F8);
@@ -317,6 +337,12 @@ public class RecordTestResult {
         }
         obj.put(RESULT, result);
         obj.put(TIME, dateFormat.format(cal.getTime()));
+        // FORTIFY Mod: validate the file path
+        ValidPath vpath = new ValidPath();
+        vpath.addElement(dirPath.toString());
+        vpath.addElement(Constants.TEST_RESULTTXT);
+        if(!vpath.isValid())
+        	throw new Exception("FORTIFY Path Error: dirPath = " + dirPath.toString() + " TEST_RESULTTXT = " + Constants.TEST_RESULTTXT);
         // write the data into file in form of json
         OutputStreamWriter writer = new OutputStreamWriter(
                 new FileOutputStream(dirPath + Constants.TEST_RESULTTXT, true), UT_F8);

--- a/teamengine-core/src/main/java/com/occamlab/te/RuntimeOptions.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/RuntimeOptions.java
@@ -15,8 +15,9 @@
  Northrop Grumman Corporation are Copyright (C) 2005-2006, Northrop
  Grumman Corporation. All Rights Reserved.
 
- Contributor(s): No additional contributors to date
- */
+ Contributor(s): 
+	C. Heazel (WiSC): Added Fortify adjudication changes 
+*/
 
 package com.occamlab.te;
 
@@ -27,6 +28,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import net.sf.saxon.s9api.XdmNode;
+
+import com.occamlab.te.util.ValidPath;  // FORTIFY Mod
 
 /**
  * Provides runtime configuration settings.
@@ -87,7 +90,13 @@ public class RuntimeOptions {
     }
 
     public void setLogDir(File logDir) {
-        this.testLogDir = logDir;
+    	// FORTIFY Mod: only allow valid testPaths
+        if(logDir != null) {
+    	       ValidPath vpath = new ValidPath();
+    	       vpath.addElement(logDir.toString());
+    	       if(vpath.isValid())  this.testLogDir = logDir;
+	   }
+        else this.testLogDir = null;
     }
 
     public File getWorkDir() {
@@ -95,7 +104,13 @@ public class RuntimeOptions {
     }
 
     public void setWorkDir(File workDir) {
-        this.workDir = workDir;
+    	// FORTIFY Mod: only allow valid testPaths
+        if(workDir != null){
+    	       ValidPath vpath = new ValidPath();
+    	       vpath.addElement(workDir.toString());
+    	       if(vpath.isValid()) this.workDir = workDir;
+        }
+        else this.workDir = null;
     }
 
     public int getMode() {
@@ -111,7 +126,14 @@ public class RuntimeOptions {
     }
 
     public void setSessionId(String sessionId) {
-        this.sessionId = sessionId;
+    	// FORTIFY Mod: sessionID is used to build path names.
+    	// Make sure there is no funny business going on.
+    	   ValidPath vpath = new ValidPath();
+        String tmpdir = System.getProperty("java.io.tmpdir");
+    	   vpath.addElement(tmpdir);  // so that there is a valid root path
+    	   vpath.addElement(sessionId);
+    	   if(vpath.isValid())
+            this.sessionId = sessionId;
     }
 
     public String getSuiteName() {
@@ -135,7 +157,11 @@ public class RuntimeOptions {
     }
 
     public void addTestPath(String testPath) {
-        this.testPaths.add(testPath);
+    	// FORTIFY Mod: only allow valid testPaths
+    	ValidPath vpath = new ValidPath();
+    	vpath.addElement(testPath);
+    	if(vpath.isValid())
+            this.testPaths.add(testPath);
     }
 
     public ArrayList<String> getParams() {
@@ -157,9 +183,12 @@ public class RuntimeOptions {
     public void setTestName(String testName) {
         this.testName = testName;
     }
-    
     public void addRecordedForm(String recordedForm) {
-      recordedForms.add(new File(recordedForm));
+        /* FORTIFY MOD: Validate that the supplied string is a valid path.*/
+    	ValidPath vpath = new ValidPath();
+    	vpath.addElement(recordedForm);
+    	if(vpath.isValid())
+            recordedForms.add(new File(vpath.getPath()));
     }
 
     @Override

--- a/teamengine-core/src/main/java/com/occamlab/te/TECore.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/TECore.java
@@ -93,6 +93,7 @@ import com.occamlab.te.util.Misc;
 import com.occamlab.te.util.SoapUtils;
 import com.occamlab.te.util.StringUtils;
 import com.occamlab.te.util.URLConnectionUtils;
+import com.occamlab.te.util.ValidPath;  // Addition for Fortify modifications
 
 import net.sf.saxon.dom.NodeOverNodeInfo;
 import net.sf.saxon.expr.XPathContext;
@@ -707,6 +708,12 @@ public class TECore implements Runnable {
     out.println("(" + testPath + ")...");
     if(opts.getLogDir()!=null){
       String logDir = opts.getLogDir() + "/" + testPath.split("/")[0];
+      //FORTIFY Mod: Path validation 
+      ValidPath vpath = new ValidPath();
+      vpath.addElement(logDir);
+      if(!vpath.isValid()) {
+    	throw new Exception("FORTIFY Path Error: logDir = " + logDir);  
+      }
       //create log directory
       if ("True".equals(System.getProperty("Record"))) {
         dirPath = new File(logDir + "/test_data");
@@ -2329,7 +2336,11 @@ public class TECore implements Runnable {
   }
 
   public void setTestPath(String testPath) {
-    this.testPath = testPath;
+	  // FORTIFY Mod: validate testPath
+	  ValidPath vpath = new ValidPath();
+	  vpath.addElement(testPath);
+	  if(vpath.isValid())
+		  this.testPath = testPath;
   }
 
   public boolean isWeb() {

--- a/teamengine-core/src/main/java/com/occamlab/te/Test.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/Test.java
@@ -17,6 +17,7 @@
 
  Contributor(s): 
  2009         F. Vitale     vitale@imaa.cnr.it
+ 2016		Charles Heazel	WiSC Enterprises
            
  */
 
@@ -38,6 +39,7 @@ import com.occamlab.te.index.Index;
 import com.occamlab.te.util.DocumentationHelper;
 import com.occamlab.te.util.LogUtils;
 import com.occamlab.te.util.Misc;
+import com.occamlab.te.util.ValidPath; // Fortify addition
 
 /**
  * 
@@ -114,7 +116,12 @@ public class Test {
                 cmd = arg.substring(5);
             } else if (arg.startsWith("-source=")) {
                 String sourcePath = arg.substring(8);
-                sourceFile = new File(sourcePath);
+                // FORTIFY Mod: validate the source path
+                ValidPath vpath = new ValidPath();
+                vpath.addElement(sourcePath);
+                if(!vpath.isValid())
+                	throw new Exception("Invalid Argument for -source " + sourcePath);
+                sourceFile = new File(vpath.getPath());
                 if (!sourceFile.isAbsolute()) {
                     File scriptsDir = new File(
                             SetupOptions.getBaseConfigDirectory(), "scripts");

--- a/teamengine-core/src/main/java/com/occamlab/te/ViewLog.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/ViewLog.java
@@ -16,7 +16,8 @@
  Northrop Grumman Corporation are Copyright (C) 2005-2006, Northrop
  Grumman Corporation. All Rights Reserved.
 
- Contributor(s): No additional contributors to date
+ Contributor(s): 
+ 	C. Heazel (WiSC): Added Fortify adjudication changes
 
  ****************************************************************************/
 package com.occamlab.te;
@@ -44,6 +45,7 @@ import org.w3c.dom.NodeList;
 import com.occamlab.te.util.DomUtils;
 import com.occamlab.te.util.LogUtils;
 import com.occamlab.te.util.Misc;
+import com.occamlab.te.util.ValidPath;  // Fortify addition
 
 /**
  * Presents a test log for display.
@@ -81,6 +83,18 @@ public class ViewLog {
           ArrayList tests, Templates templates, Writer out, int testnum)
           throws Exception {
     hasCache = false;
+    // FORTIFY MOD: don't allow invalid path names
+    ValidPath vpath = new ValidPath();
+    vpath.addElement(logdir.toString());
+    if (!vpath.isValid()){
+        System.out.println("Error: illegal viewlog logdir parameter " + logdir.toString());
+        return false;
+    }
+    vpath.addElement(session);
+    if (!vpath.isValid()){
+        System.out.println("Error: illegal viewlog session parameter " + session);
+        return false;
+    }
     Transformer t = templates.newTransformer();
     t.setParameter("sessionDir", session);
     t.setParameter("TESTNAME", suiteName);
@@ -126,7 +140,11 @@ public class ViewLog {
       while (it.hasNext()) {
         String test = (String) it.next();
         File f = new File(new File(logdir, test), "log.xml");
-        if (f.exists()) {
+        // FORTIFY MOD: don't allow invalid path names
+        vpath = new ValidPath();
+        vpath.addElement(f.getAbsolutePath());
+        if (vpath.isValid() && f.exists()) {  
+        //if (f.exists()) {
           Document doc = LogUtils.makeTestList(logdir, test);
           Element testElement = DomUtils.getElementByTagName(doc,
                   "test");

--- a/teamengine-core/src/main/java/com/occamlab/te/util/LogUtils.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/util/LogUtils.java
@@ -50,6 +50,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import com.occamlab.te.TECore;
+import com.occamlab.te.util.ValidPath;  // Addition for Fortify modifications
 
 public class LogUtils {
 
@@ -58,6 +59,7 @@ public class LogUtils {
 
     /**
      * Creates a Writer used to write test results to the log.xml file.
+     * FORTIFY MOD: Validate the path to the log file.
      * 
      * @param logDir
      *            The directory containing the test session results.
@@ -70,6 +72,13 @@ public class LogUtils {
     public static PrintWriter createLog(File logDir, String callpath)
             throws Exception {
         if (logDir != null) {
+            /*  FORTIFY MOD: first do path validity check */
+            ValidPath vpath = new ValidPath();
+            vpath.addElement(logDir.getAbsolutePath());
+            vpath.addElement(callpath);
+            if(!vpath.isValid()) {
+            	throw new Exception("FORTIFY Path Error: logDir = " + logDir.toString() + " callpath = " + callpath);
+            }
             File dir = new File(logDir, callpath);
             String path=logDir.toString() + "/" + callpath.split("/")[0];
             System.setProperty("PATH", path);
@@ -209,6 +218,14 @@ public class LogUtils {
 
     private static Element makeTestListElement(DocumentBuilder db,
             Document owner, File logdir, String path) throws Exception {
+    	/*  FORTIFY MOD: validate log path prior to creation */
+    	ValidPath vpath = new ValidPath();
+    	vpath.addElement(logdir.getAbsolutePath());
+    	vpath.addElement(path);
+    	vpath.addElement("log.xml");
+    	if(!vpath.isValid()) {
+    		throw new Exception("FORTIFY Path Error: logdir = " + logdir.toString() + " path = " + path);
+    	}
         File log = new File(new File(logdir, path), "log.xml");
         Document logdoc = LogUtils.readLog(log.getParentFile(), ".");
         if (logdoc == null) {
@@ -281,12 +298,20 @@ public class LogUtils {
      */
     public static Document makeTestList(File logdir, String path,
             List<List<QName>> excludes) throws Exception {
+        // FORTIFY MOD: validate the logdir and path arguments. 
+        ValidPath vpath = new ValidPath();
+        vpath.addElement(logdir.getAbsolutePath());
+        vpath.addElement(path);
+        if(!vpath.isValid()) {
+        	throw new Exception("FORTIFY Path Error: logdir = " + logdir.toString() + " path = " + path);
+        }
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
 	   // Fortify Mod: Disable entity expansion to foil External Entity Injections
 	   dbf.setExpandEntityReferences(false);
         DocumentBuilder db = dbf.newDocumentBuilder();
         Document doc;
+        // FORTIFY MOD: logdir and path have already been validated.
         File testListFile = new File(logdir, path + File.separator
                 + "testlist.xml");
         long testListDate = testListFile.lastModified();
@@ -340,6 +365,11 @@ public class LogUtils {
     private static Element updateTestListElement(DocumentBuilder db,
             Element test, File logdir, long testListDate) throws Exception {
         String path = test.getAttribute("path");
+        // FORTIFY Mod: validate the path
+        ValidPath vpath = new ValidPath();
+        vpath.addElement(logdir.toString());
+        vpath.addElement(path);
+        if(!vpath.isValid()) throw new Exception("FORTIFY Path Error: logdir = " + logdir.toString() + " path = " + path);
         long logdate = 0;
         if (testListDate > 0) {
             logdate = new File(logdir, path + File.separator + "log.xml")
@@ -412,6 +442,10 @@ public class LogUtils {
     public static String generateSessionId(File logDir) {
         int i = 1;
         String session = "s0001";
+        /* FORTIFY MOD: check that the path is valid */
+        ValidPath vpath = new ValidPath();
+        vpath.addElement(logDir.toString());
+        if(!vpath.isValid()) return null;
         while (new File(logDir, session).exists() && i < 10000) {
             i++;
             session = "s" + Integer.toString(10000 + i).substring(1);
@@ -431,6 +465,13 @@ public class LogUtils {
      */
     public static void createFullReportLog(String sessionLogDir)
             throws Exception {
+    	/* FORTIFY MOD: Validate sessonLogDir parameter */
+    	ValidPath vpath = new ValidPath();
+    	vpath.addElement(sessionLogDir);
+    	if(!vpath.isValid()) 
+    	{
+    		throw new Exception("FORTIFY Path Error: path name = " + sessionLogDir);
+    	}
         File xml_logs_report_file = new File(sessionLogDir + File.separator
                 + "report_logs.xml");
         if (xml_logs_report_file.exists()) {

--- a/teamengine-core/src/main/java/com/occamlab/te/util/ValidPath.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/util/ValidPath.java
@@ -1,0 +1,128 @@
+package com.occamlab.te.util;
+
+import java.util.logging.Logger;
+
+/**
+ * This utility was developed to address security vulnerabilities due to manipulation
+ * of the file system path.  It restricts file system paths to those which are known 
+ * to be safe.  The specific rules applied are described in-line below.  
+ * 
+ * @version August 01 2016
+ * @author Charles Heazel
+ */
+public class ValidPath {
+
+    private String path = null;
+    private String tmpdir = null;
+    private String te_install = null;
+    private String te_base = null;
+    private String te_build = null;
+    private String user_home = null;
+    private String separator = null;
+    private static Logger jlogger = Logger.getLogger("com.occamlab.te.util.ValidPath");
+
+    public ValidPath() {
+    	// Make every effort to populate these strings with something 
+    	// even if it is made up.
+        path = new String();
+        separator = System.getProperty("file.separator");
+        if(separator == null) separator = "/";
+        te_base = System.getProperty("TE_BASE");
+        if(te_base == null) te_base = System.getenv("TE_BASE");
+        if(te_base == null) te_base = "/TE_BASE";
+        tmpdir = System.getProperty("java.io.tmpdir");
+        if(tmpdir == null) tmpdir = te_base;
+        te_install = System.getProperty("TE_INSTALL");
+        if(te_install == null) te_install = System.getenv("TE_INSTALL");
+        if(te_install == null) te_install = te_base;
+        te_build = System.getenv("TE_BUILD");
+        if(te_build == null) te_build = te_base;
+        user_home = System.getenv("HOME");
+        if(user_home == null) user_home = te_base;
+        
+        // Force windows first character to lower case
+        if(tmpdir.startsWith("C:")) tmpdir = tmpdir.replaceFirst("^C:", "c:");
+        if(te_install.startsWith("C:")) te_install = te_install.replaceFirst("^C:", "c:");
+        if(te_base.startsWith("C:")) te_base = te_base.replaceFirst("^C:", "c:");
+        if(te_build.startsWith("C:")) te_build = te_build.replaceFirst("^C:", "c:");
+        if(user_home.startsWith("C:")) user_home = user_home.replaceFirst("^C:", "c:");
+    }
+
+    public boolean addElement( String arg1 ) {
+        // NULL case - return true since nothing was done.
+        if( arg1 == null) return(true);
+
+        // convert the separators
+        if(separator.equals("/")) arg1 = arg1.replace("\\", separator);
+        if(separator.equals("\\")) arg1 = arg1.replace("/", separator);
+        
+        // Force windows first character to lower case
+        if(arg1.startsWith("C:")) {
+        	arg1 = arg1.replaceFirst("^C:", "c:");
+        }
+    	
+        // IF a relative path, strip off the relative part
+        while(arg1.startsWith(".")) arg1 = arg1.substring(1);
+
+    	// IF the path is not empty and does not end with a separator, add one.
+    	if(!path.isEmpty() && !path.endsWith(separator)){
+    		path = path.concat(separator);
+    	}
+
+    	// Append the element.  
+        path = path.concat( arg1 );
+        
+        // This comes in handy when a change to the code requires a change to the ValidPath rules.
+        // jlogger.info("VALIDPATH Add Element = " + path);
+
+    	  // Validate it.
+        if(this.validate(path)) return(true);
+        return(false);
+    }
+
+    public String getPath() {
+    	// Only return a path if it is valid
+    	if(this.validate(path)) return(path);
+    	// If it is an invalid path, get rid of it
+    	// Unfortunately Java does not allow us to destroy objects.  So the best we can do is dereference it.
+    	path = new String();
+        return(null);
+    }
+    
+    public boolean isValid() {
+    	if(this.validate(path)) return(true);
+    	return(false);
+    }
+    
+    private boolean validate( String arg1 ){
+
+    	// Validate checks the path supplied in the argument against a set of rules
+    	// for a valid path.  Changes to the source over time may require adjustments
+    	// to these rules.
+
+        // a null path is still valid
+        if(arg1 == null) return(true);
+        
+    	// Restrict the path to one of the valid root directories
+    	boolean valid = false;
+    	if(arg1.startsWith(te_base)) valid = true; 
+    	if(arg1.startsWith(te_install)) valid = true; 
+    	if(arg1.startsWith(tmpdir)) valid = true;
+    	if(arg1.startsWith(te_build)) valid = true;
+    	
+    	// No navigating up the directory tree
+    	if(arg1.contains("..")) valid = false;
+    	
+    	// These are never allowed
+    	if(arg1.startsWith("c:\\Windows")) valid = false; 
+    	if(arg1.startsWith("/etc")) valid = false; 
+    	if(arg1.startsWith("/bin")) valid = false; 
+    	if(arg1.startsWith("/usr/bin")) valid = false; 
+    	
+    	if(valid == false){
+           jlogger.warning("VALIDPATH Invalid Path: " + arg1);
+    	}
+    	return(valid);
+    }
+}
+

--- a/teamengine-core/src/test/java/com/occamlab/te/util/ValidPathTest.java
+++ b/teamengine-core/src/test/java/com/occamlab/te/util/ValidPathTest.java
@@ -1,0 +1,68 @@
+package com.occamlab.te.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * This junit test exercises the ValidPath class ValidPath addresses security vulnerabilities
+ * due to manipulation of the file system path. 
+ * 
+ * @version July 30 2016
+ * @author Charles Heazel
+ */
+
+public class ValidPathTest {
+	// Determine if we are using Windows or Unix path names
+	// Select the appropriate set of test paths
+	private static String test1 = null;
+	private static String test2 = null;
+	private static String test3 = null;
+	private static String test4 = null;
+
+	@BeforeClass
+	public static void initialize() {
+		String separator = System.getProperty("file.separator");
+		if(separator.equals("/")) {
+			test1 = "/TE_BASE";
+			test2 = "/etc/init.d";      // Path root is restricted
+			test3 = "/TE_BASE/../etc";  // Navigation up the tree is not allowed
+			test4 = "/usr/tmp/foo-bar"; // Valid path name
+		}
+		if(separator.equals("\\")) {
+			test1 = "c:\\TE_BASE";
+			test2 = "c:\\Windows";              // Path root is restricted
+			test3 = "c\\TE_BASE\\..\\Windows";  // Navigation up the tree is not allowed
+			test4 = "c:\\TE_BASE\\foo-bar";        // Valid path name
+		}
+	}
+
+	@Test
+	public void testAddElement() {
+		ValidPath vpath = new ValidPath();
+		vpath.addElement(test1);
+		vpath.addElement("foo-bar");
+		boolean valid = vpath.isValid();
+		assertTrue("Expected ValidPath should be " + test4 + ".", valid);
+	}
+
+	@Test
+	public void testGetPath() {
+		ValidPath vpath = new ValidPath();
+		vpath.addElement(test2);
+		assertNull("Expected null for ValidPath.getPath() for " + test2, vpath.getPath());
+	}
+
+	@Test
+	public void testIsValid() {
+		ValidPath vpath1 = new ValidPath();
+		vpath1.addElement(test2);
+		assertFalse("Expected false for ValidPath.isValid() for " + test2, vpath1.isValid());
+		ValidPath vpath2 = new ValidPath();
+		vpath2.addElement(test3);
+		assertFalse("Expected false for ValidPath.isValid() for " + test3, vpath2.isValid());
+	}
+}
+

--- a/teamengine-realm/pom.xml
+++ b/teamengine-realm/pom.xml
@@ -27,6 +27,11 @@
       <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>teamengine-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/teamengine-realm/src/main/java/com/occamlab/te/realm/PBKDF2Realm.java
+++ b/teamengine-realm/src/main/java/com/occamlab/te/realm/PBKDF2Realm.java
@@ -20,6 +20,7 @@ import org.w3c.dom.NodeList;
 
 import com.occamlab.te.realm.PasswordStorage.CannotPerformOperationException;
 import com.occamlab.te.realm.PasswordStorage.InvalidHashException;
+import com.occamlab.te.util.ValidPath; // FORTIFY Mod.
 
 /**
  * A custom Tomcat Realm implementation that reads user information from an XML
@@ -45,6 +46,9 @@ import com.occamlab.te.realm.PasswordStorage.InvalidHashException;
  * 
  * @see <a href="https://github.com/defuse/password-hashing">Secure Password
  *      Storage v2.0</a>
+ *  
+ * @author "Richard Martell (Galdos)"
+ * @author "C. Heazel (WiSC): Added Fortify adjudication changes"
  */
 public class PBKDF2Realm extends RealmBase {
 
@@ -133,7 +137,10 @@ public class PBKDF2Realm extends RealmBase {
      *            A String specifying a directory location (TE_BASE/users).
      */
     public void setRoot(String root) {
-        rootPath = root;
+    	//FORTIFY MOD: Validate the new root path is valid
+    	ValidPath vpath = new ValidPath();
+    	vpath.addElement(root);
+        rootPath = vpath.getPath();
     }
 
     private GenericPrincipal readPrincipal(String username) {

--- a/teamengine-spi/pom.xml
+++ b/teamengine-spi/pom.xml
@@ -53,6 +53,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>teamengine-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>jsr311-api</artifactId>
       <version>1.1.1</version>

--- a/teamengine-spi/src/main/java/com/occamlab/te/spi/executors/testng/TestNGExecutor.java
+++ b/teamengine-spi/src/main/java/com/occamlab/te/spi/executors/testng/TestNGExecutor.java
@@ -1,3 +1,11 @@
+/**
+ * **************************************************************************
+ *
+ * Contributor(s): 
+ *	C. Heazel (WiSC): Added Fortify adjudication changes
+ *
+ ***************************************************************************
+ */
 package com.occamlab.te.spi.executors.testng;
 
 import java.io.File;
@@ -23,11 +31,16 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
+import com.occamlab.te.util.ValidPath; // FORTIFY Mod.
+
 import com.occamlab.te.spi.executors.TestRunExecutor;
 
 /**
  * 
  * Executes a TestNG test suite using the given test run arguments.
+ * 
+ *  Contributor(s): 
+ *	    C. Heazel (WiSC): Added Fortify adjudication changes
  */
 public class TestNGExecutor implements TestRunExecutor {
 
@@ -64,6 +77,11 @@ public class TestNGExecutor implements TestRunExecutor {
      */
     public TestNGExecutor(String testngSuite, String outputDirPath, boolean useDefaultListeners) {
         this.useDefaultListeners = useDefaultListeners;
+        // FORTIFY MOD: validate the outputDirPath parameter.
+        ValidPath vpath = new ValidPath();
+        vpath.addElement(outputDirPath);
+        // If path is invalid will return a null
+        outputDirPath = vpath.getPath();
         this.outputDir = new File(outputDirPath, "testng");
         if (!this.outputDir.exists() && !this.outputDir.mkdirs()) {
             LOGR.config("Failed to create output directory at " + this.outputDir);

--- a/teamengine-web/src/main/webapp/viewSessionLog.jsp
+++ b/teamengine-web/src/main/webapp/viewSessionLog.jsp
@@ -35,8 +35,8 @@ public void jspInit() {
   Northrop Grumman Corporation are Copyright (C) 2005-2006, Northrop
   Grumman Corporation. All Rights Reserved.
 
-  Contributor(s): No additional contributors to date
-
+  Contributor(s): 
+      C. Heazel (WiSC): Added Fortify adjudication changes
  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 <%@page import="java.net.URLEncoder"%>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US" lang="en-US">
@@ -90,6 +90,14 @@ public void jspInit() {
 <%
       File userlog = new File(Conf.getUsersDir(), request.getRemoteUser());
       String sessionId = request.getParameter("session");
+      // FORTIFY MOD: make sure userlog and sessionId do not form an illegal path
+      ValidPath vpath = new ValidPath();
+      vpath.addElement( userlog.getAbsolutePath() );
+      vpath.addElement( sessionId );
+      if(!vpath.isValid()) {
+          userlog = null;
+          sessionId = null;
+      }
       TestSession ts = new TestSession();
       ts.load(userlog, sessionId);
       String suiteName = "null";


### PR DESCRIPTION
Added a ValidPath class which validates that the path is legal before it is used.  The rules in ValidPath require that a path:
1) is rooted at:
    - TE_BASE
    - TE_INSTALL
    - java.io.tmpdir
    - TE_BUILD
2) does not include the string ".."
3) is not rooted at:
    - c:\Windows
    - /etc
    - /bin
    - /usr/bin

The environment variables listed in item 1 must be set or paths will not validate.