### PR TITLE
Removed dependency to ets-wfs20

### DIFF
--- a/teamengine-virtualization/pom.xml
+++ b/teamengine-virtualization/pom.xml
@@ -113,25 +113,10 @@
       <classifier>base</classifier>
       <type>zip</type>
     </dependency>
-    <dependency>
-      <groupId>org.opengis.cite</groupId>
-      <artifactId>ets-wfs20</artifactId>
-      <version>${ets-wfs20.version}</version>
-      <classifier>ctl</classifier>
-      <type>zip</type>
-    </dependency>
-    <dependency>
-      <groupId>org.opengis.cite</groupId>
-      <artifactId>ets-wfs20</artifactId>
-      <version>${ets-wfs20.version}</version>
-      <classifier>deps</classifier>
-      <type>zip</type>
-    </dependency>
   </dependencies>
 
   <properties>
     <docker.image.prefix>opengis</docker.image.prefix>
     <docker.image.name>teamengine</docker.image.name>
-    <ets-wfs20.version>1.22</ets-wfs20.version>
   </properties>
 </project>

--- a/teamengine-virtualization/src/main/config/docker/Dockerfile
+++ b/teamengine-virtualization/src/main/config/docker/Dockerfile
@@ -20,14 +20,5 @@ RUN cd /root/ && unzip -q teamengine-console-${TEAMENGINE_VERSION}-base.zip -d /
 # set TE_BASE
 ENV JAVA_OPTS="-Xms1024m -Xmx2048m -DTE_BASE=/root/te_base"
 
-# set WFS 2.0 ETS version
-ENV ETS_WFS_20_VERSION 1.22
-
-# add ETS for WFS 2.0
-ADD ets-wfs20-${ETS_WFS_20_VERSION}-ctl.zip /root/
-RUN cd /root/ && unzip -q ets-wfs20-${ETS_WFS_20_VERSION}-ctl.zip -d /root/te_base/scripts
-ADD ets-wfs20-${ETS_WFS_20_VERSION}-deps.zip /root/
-RUN cd /root/ && unzip -q -o ets-wfs20-${ETS_WFS_20_VERSION}-deps.zip -d /usr/local/tomcat/webapps/teamengine/WEB-INF/lib
-
 # run tomcat
 CMD ["catalina.sh", "run"]


### PR DESCRIPTION
This pull request removes the dependency to ets-wfs20. Thus, the artefacts must not be available in a reachable repository.

Fix for #185.
