### PR TITLE
Update SchematronValidatingParser.java

### DIFF
--- a/teamengine-core/src/main/java/com/occamlab/te/parsers/SchematronValidatingParser.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/parsers/SchematronValidatingParser.java
@@ -408,13 +408,13 @@ public class SchematronValidatingParser {
         XmlErrorHandler errHandler = new XmlErrorHandler();
         builder.put(ValidateProperty.ERROR_HANDLER, errHandler);
         ValidationDriver driver = createDriver(builder.toPropertyMap());
-        InputStream schStream = this.getClass().getResourceAsStream(schemaRef);
+        InputStream schStream = this.getClass().getResourceAsStream(schemaRef.trim());
         try {
             InputSource input = new InputSource(schStream);
             try {
                 boolean loaded = driver.loadSchema(input);
                 if (!loaded) {
-                    throw new Exception("Failed to load schema at " + schemaRef
+                    throw new Exception("Failed to load schema at " + schemaRef.trim()
                             + "\nIs the schema valid? Is the phase defined?");
                 }
             } finally {


### PR DESCRIPTION
XML formatting (cf. Source/Format in Eclipse) may add newlines causing parsing errors, e.g. see <ctl:with-param>.
This change should make the tests more robust wrt whitespace.

Alternative strategy: remove newlines with xslt in ctl scripts (main.xml, test
ctl:SchematronValidatingParser).

The solution in the pull seems preferable, as it is more generic and valid for all ctl based ets.
Credits: Lyn@lat-lon.de :-)