### PR TITLE
Prevents External Entity Injections

### DIFF
--- a/teamengine-core/src/main/java/com/occamlab/te/CtlEarlReporter.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/CtlEarlReporter.java
@@ -1,3 +1,14 @@
+/**
+ * *******************************************************************************
+ *
+ * Version Data: January 2, 2018
+ *
+ * Contributor(s):
+ *    C. Heazel (WiSC): Fortify adjudictions
+ *
+ * *******************************************************************************
+ */
+
 package com.occamlab.te;
 
 import java.io.File;
@@ -19,6 +30,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -89,6 +101,9 @@ public class CtlEarlReporter {
         DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
         docFactory.setNamespaceAware(true);
         docFactory.setXIncludeAware(true);
+        // Fortify Mod: Disable entity expansion to foil External Entity Injections
+        docFactory.setExpandEntityReferences(false);
+        // End Fortify Mod
         // Source results = null;
         Document document;
         try {
@@ -503,8 +518,11 @@ public class CtlEarlReporter {
 						} else if (httpMethod.equalsIgnoreCase("POST")) {
 							// Post method content
 							try {
-								Transformer transformer = TransformerFactory
-										.newInstance().newTransformer();
+                                                                // Fortify Mod: Prevent external entity injections
+								// Transformer transformer = TransformerFactory.newInstance().newTransformer();
+								TransformerFactory tf = TransformerFactory.newInstance();
+                                                                tf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+								Transformer transformer = tf.newTransformer();
 								transformer.setOutputProperty(
 										OutputKeys.INDENT, "yes");
 

--- a/teamengine-core/src/main/java/com/occamlab/te/TECore.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/TECore.java
@@ -919,6 +919,9 @@ public class TECore implements Runnable {
 		File logfile = new File(logdir);
 		try {
 			dbf = DocumentBuilderFactory.newInstance();
+			// Fortify Mod: Disable entity expansion to foil External Entity Injections
+                        dbf.setExpandEntityReferences(false);
+                        // End Fortify Mod
 			docBuilder = dbf.newDocumentBuilder();
 			docBuilder.setErrorHandler(null);
 			doc = docBuilder.parse(logfile);
@@ -956,6 +959,9 @@ public class TECore implements Runnable {
 
 				TransformerFactory transformerFactory = TransformerFactory
 						.newInstance();
+                                // Fortify Mod: prevent external entity injection
+                                transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                                // END Fortify Mod
 				Transformer transformer = transformerFactory.newTransformer();
 				transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 				StreamResult result = new StreamResult(logfile);
@@ -2496,7 +2502,12 @@ public class TECore implements Runnable {
         
         try {
             if ( earlResult != null && earlResult.exists() ) {
-                Transformer transformer = TransformerFactory.newInstance().newTransformer( new StreamSource( earlXsl ) );
+                // Fortify Mod: prevent external entity injections
+                // Transformer transformer = TransformerFactory.newInstance().newTransformer( new StreamSource( earlXsl ) );
+                TransformerFactory tf = TransformerFactory.newInstance();
+                tf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                Transformer transformer = tf.newTransformer( new StreamSource( earlXsl ) );
+                // End Fortify Mod
                 transformer.setParameter( "outputDir", htmlOutput );
                 File indexHtml = new File( htmlOutput, "index.html" );
                 indexHtml.createNewFile();

--- a/teamengine-realm/src/main/java/com/occamlab/te/realm/PBKDF2Realm.java
+++ b/teamengine-realm/src/main/java/com/occamlab/te/realm/PBKDF2Realm.java
@@ -1,3 +1,13 @@
+/**
+ * ***********************************************************************************
+ *
+ *  Version Date: January 2, 2018
+ *
+ *  Contributor(s):
+ *     C. Heazel (WiSC): Added Fortify adjudication changes
+ *
+ * ***********************************************************************************
+ */
 package com.occamlab.te.realm;
 
 import java.io.File;
@@ -149,7 +159,12 @@ public class PBKDF2Realm extends RealmBase {
         Document userInfo = null;
         try {
             if (DB == null) {
-                DB = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+                // Fortify Mod: Disable external expansion to foil External Entity Injections
+                // DB = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+                DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                dbf.setExpandEntityReferences(false);
+                DB = dbf.newDocumentBuilder();
+                // End Fortify Mod
             }
             userInfo = DB.parse(userfile);
         } catch (Exception e) {

--- a/teamengine-spi-ctl/src/main/java/com/occamlab/te/spi/ctl/CtlExecutor.java
+++ b/teamengine-spi-ctl/src/main/java/com/occamlab/te/spi/ctl/CtlExecutor.java
@@ -1,3 +1,14 @@
+/**
+ * ***********************************************************************************
+ *
+ *  Version Date: January 2, 2018
+ *
+ *  Contributor(s):
+ *     C. Heazel (WiSC): Fortify adjudications
+ *
+ * ***********************************************************************************
+ */
+
 package com.occamlab.te.spi.ctl;
 
 import com.occamlab.te.CtlEarlReporter;
@@ -104,6 +115,9 @@ public class CtlExecutor implements TestRunExecutor {
         // NOTE: Final result should be transformed to EARL report (RDF/XML)
         // resolve xinclude directives in CTL results
         DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        // Fortify Mod: Disable entity expansion to foil External Entity Injection
+        docFactory.setExpandEntityReferences(false);
+        // End Fortify Mod
         docFactory.setNamespaceAware(true);
         docFactory.setXIncludeAware(true);
         Source results = null;

--- a/teamengine-spi/src/main/java/com/occamlab/te/spi/util/HtmlReport.java
+++ b/teamengine-spi/src/main/java/com/occamlab/te/spi/util/HtmlReport.java
@@ -1,3 +1,14 @@
+/**
+ * ********************************************************************
+ *
+ * Version Date: January 2, 2018
+ *
+ * Contributor(s):
+ *    C. Heazel (WiSC): Added Fortify adjudication changes
+ *
+ * ********************************************************************
+ */
+
 package com.occamlab.te.spi.util;
 
 import java.io.File;
@@ -10,6 +21,7 @@ import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
@@ -69,8 +81,12 @@ public class HtmlReport {
 		File earlResult = new File(outputDir, "earl-results.rdf");
 
 		try {
-			Transformer transformer = TransformerFactory.newInstance()
-					.newTransformer(new StreamSource(earlXsl));
+                        // Fortify Mod: Prevent external entity injections
+			// Transformer transformer = TransformerFactory.newInstance().newTransformer(new StreamSource(earlXsl));
+			TransformerFactory tf = TransformerFactory.newInstance();
+                        tf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		        Transformer transformer = tf.newTransformer(new StreamSource(earlXsl));
+                        // End Fortify Mod
 			transformer.setParameter("outputDir", htmlOutput);
             File indexHtml = new File(htmlOutput, "index.html" );
             indexHtml.createNewFile();

--- a/teamengine-web/src/main/java/com/occamlab/te/web/listeners/CleartextPasswordContextListener.java
+++ b/teamengine-web/src/main/java/com/occamlab/te/web/listeners/CleartextPasswordContextListener.java
@@ -1,3 +1,14 @@
+/**
+ * ******************************************************************************************
+ *
+ * Version Date: January 2, 2018
+ *
+ * Contributor(s):
+ *     C. Heazel (WiSC): Fortify adjudications
+ *
+ * ******************************************************************************************
+ */
+
 package com.occamlab.te.web.listeners;
 
 import java.io.File;
@@ -57,7 +68,12 @@ public class CleartextPasswordContextListener implements ServletContextListener 
         }
         DocumentBuilder domBuilder = null;
         try {
-            domBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            // Fortify Mod: Disable entity expansion to foil External Entity Injections
+            // domBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setExpandEntityReferences(false);
+            domBuilder = dbf.newDocumentBuilder();
+            // End Fortify Mod
         } catch (ParserConfigurationException e) {
             LOGR.warning(e.getMessage());
             return;


### PR DESCRIPTION
Provides protections against attempts to use external XML entities to compromise the TeamEngine.  These modifications address the remaining External Entity Injection vulnerabilities identified through the Fortify scan.

Fixes #293.