### PR TITLE
MPL License Removed

### DIFF
--- a/teamengine-core/src/main/java/com/occamlab/te/CtlErrorHandler.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/CtlErrorHandler.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/ 
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License. 
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-core/src/main/java/com/occamlab/te/Engine.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/Engine.java
@@ -1,12 +1,4 @@
 /*
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
 
  The Original Code is TEAM Engine.
 

--- a/teamengine-core/src/main/java/com/occamlab/te/Generator.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/Generator.java
@@ -1,12 +1,4 @@
 /*
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
 
  The Original Code is TEAM Engine.
 

--- a/teamengine-core/src/main/java/com/occamlab/te/NullErrorListener.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/NullErrorListener.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/ 
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License. 
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-core/src/main/java/com/occamlab/te/RuntimeOptions.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/RuntimeOptions.java
@@ -1,12 +1,4 @@
 /*
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
 
  The Original Code is TEAM Engine.
 

--- a/teamengine-core/src/main/java/com/occamlab/te/TEClassLoader.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/TEClassLoader.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-core/src/main/java/com/occamlab/te/TECore.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/TECore.java
@@ -1,13 +1,6 @@
 /**
  * **************************************************************************
  *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with the
- * License. You may obtain a copy of the License at http://www.mozilla.org/MPL/
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- * the specific language governing rights and limitations under the License.
- *
  * The Original Code is TEAM Engine.
  *
  * The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-core/src/main/java/com/occamlab/te/TeErrorListener.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/TeErrorListener.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/ 
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License. 
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-core/src/main/java/com/occamlab/te/Test.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/Test.java
@@ -1,12 +1,4 @@
 /*
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
 
  The Original Code is TEAM Engine.
 

--- a/teamengine-core/src/main/java/com/occamlab/te/ViewLog.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/ViewLog.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-core/src/main/java/com/occamlab/te/index/Index.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/index/Index.java
@@ -1,12 +1,4 @@
 /*
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
 
  The Original Code is TEAM Engine.
 

--- a/teamengine-core/src/main/java/com/occamlab/te/parsers/CDataParser.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/parsers/CDataParser.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-core/src/main/java/com/occamlab/te/parsers/HTTPParser.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/parsers/HTTPParser.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/ 
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License. 
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-core/src/main/java/com/occamlab/te/parsers/ImageParser.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/parsers/ImageParser.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-core/src/main/java/com/occamlab/te/parsers/NullParser.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/parsers/NullParser.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-core/src/main/java/com/occamlab/te/parsers/SoapParser.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/parsers/SoapParser.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
-The contents of this file are subject to the Mozilla Public License
-Version 1.1 (the "License"); you may not use this file except in
-compliance with the License. You may obtain a copy of the License at
-http://www.mozilla.org/MPL/
-
-Software distributed under the License is distributed on an "AS IS" basis,
-WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-the specific language governing rights and limitations under the License.
-
 The Original Code is TEAM Engine.
 
 The Initial Developer of the Original Code is Intecs SPA.  Portions created by

--- a/teamengine-core/src/main/java/com/occamlab/te/util/DocumentationHelper.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/util/DocumentationHelper.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Fabrizio Vitale

--- a/teamengine-core/src/main/java/com/occamlab/te/util/Misc.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/util/Misc.java
@@ -1,13 +1,4 @@
 /*
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-core/src/main/java/com/occamlab/te/util/Soap11MessageBuilder.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/util/Soap11MessageBuilder.java
@@ -1,12 +1,4 @@
 /****************************************************************************
-The contents of this file are subject to the Mozilla Public License
-Version 1.1 (the "License"); you may not use this file except in
-compliance with the License. You may obtain a copy of the License at
-http://www.mozilla.org/MPL/
-
-Software distributed under the License is distributed on an "AS IS" basis,
-WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-the specific language governing rights and limitations under the License.
 
 The Original Code is TEAM Engine.
 

--- a/teamengine-core/src/main/java/com/occamlab/te/util/Soap12MessageBuilder.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/util/Soap12MessageBuilder.java
@@ -1,12 +1,4 @@
 /****************************************************************************
-The contents of this file are subject to the Mozilla Public License
-Version 1.1 (the "License"); you may not use this file except in
-compliance with the License. You may obtain a copy of the License at
-http://www.mozilla.org/MPL/
-
-Software distributed under the License is distributed on an "AS IS" basis,
-WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-the specific language governing rights and limitations under the License.
 
 The Original Code is TEAM Engine.
 

--- a/teamengine-core/src/main/java/com/occamlab/te/util/SoapUtils.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/util/SoapUtils.java
@@ -1,12 +1,4 @@
 /****************************************************************************
- * The contents of this file are subject to the Mozilla Public License
- * Version 1.1 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- * the specific language governing rights and limitations under the License.
  *
  * The Original Code is TEAM Engine.
  *

--- a/teamengine-core/src/main/java/com/occamlab/te/util/protocols/data/Handler.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/util/protocols/data/Handler.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-core/src/main/java/net/sf/saxon/s9api/S9APIUtils.java
+++ b/teamengine-core/src/main/java/net/sf/saxon/s9api/S9APIUtils.java
@@ -1,12 +1,4 @@
 /*
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
 
  The Original Code is TEAM Engine.
 

--- a/teamengine-resources/src/main/resources/com/occamlab/te/PseudoCTLDocumentation.xsl
+++ b/teamengine-resources/src/main/resources/com/occamlab/te/PseudoCTLDocumentation.xsl
@@ -2,14 +2,6 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
     xmlns:ctl="http://www.occamlab.com/ctl">
 <!--
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
 
  The Original Code is TEAM Engine.
 

--- a/teamengine-resources/src/main/resources/com/occamlab/te/formfn.xsl
+++ b/teamengine-resources/src/main/resources/com/occamlab/te/formfn.xsl
@@ -1,14 +1,5 @@
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-resources/src/main/resources/com/occamlab/te/generate_dxsl.xsl
+++ b/teamengine-resources/src/main/resources/com/occamlab/te/generate_dxsl.xsl
@@ -1,14 +1,5 @@
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-resources/src/main/resources/com/occamlab/te/generate_source_html.xsl
+++ b/teamengine-resources/src/main/resources/com/occamlab/te/generate_source_html.xsl
@@ -1,14 +1,5 @@
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-resources/src/main/resources/com/occamlab/te/generate_xsl.xsl
+++ b/teamengine-resources/src/main/resources/com/occamlab/te/generate_xsl.xsl
@@ -1,14 +1,5 @@
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-resources/src/main/resources/com/occamlab/te/logstyles/default.xsl
+++ b/teamengine-resources/src/main/resources/com/occamlab/te/logstyles/default.xsl
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-resources/src/main/resources/com/occamlab/te/main.xsl
+++ b/teamengine-resources/src/main/resources/com/occamlab/te/main.xsl
@@ -1,14 +1,5 @@
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-resources/src/main/resources/com/occamlab/te/scripts/parsers.ctl
+++ b/teamengine-resources/src/main/resources/com/occamlab/te/scripts/parsers.ctl
@@ -1,14 +1,5 @@
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-spi/src/main/java/com/occamlab/te/spi/vocabulary/Config.java
+++ b/teamengine-spi/src/main/java/com/occamlab/te/spi/vocabulary/Config.java
@@ -1,13 +1,7 @@
 
 /****************************************************************************
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
  The Original Code is TEAM Engine.
+ 
  The Initial Developer of the Original Code is Northrop Grumman Corporation
  jointly with The National Technology Alliance.  Portions created by
  Northrop Grumman Corporation are Copyright (C) 2005-2006, Northrop

--- a/teamengine-web/src/main/java/com/occamlab/te/web/Config.java
+++ b/teamengine-web/src/main/java/com/occamlab/te/web/Config.java
@@ -1,13 +1,7 @@
 
 /****************************************************************************
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
  The Original Code is TEAM Engine.
+ 
  The Initial Developer of the Original Code is Northrop Grumman Corporation
  jointly with The National Technology Alliance.  Portions created by
  Northrop Grumman Corporation are Copyright (C) 2005-2006, Northrop

--- a/teamengine-web/src/main/java/com/occamlab/te/web/DeleteSessionServlet.java
+++ b/teamengine-web/src/main/java/com/occamlab/te/web/DeleteSessionServlet.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/ 
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License. 
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/java/com/occamlab/te/web/RegistrationHandlerServlet.java
+++ b/teamengine-web/src/main/java/com/occamlab/te/web/RegistrationHandlerServlet.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/ 
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License. 
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/java/com/occamlab/te/web/TestServlet.java
+++ b/teamengine-web/src/main/java/com/occamlab/te/web/TestServlet.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License.
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/java/com/occamlab/te/web/TestSession.java
+++ b/teamengine-web/src/main/java/com/occamlab/te/web/TestSession.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/ 
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License. 
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/java/com/occamlab/te/web/ViewLogServlet.java
+++ b/teamengine-web/src/main/java/com/occamlab/te/web/ViewLogServlet.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/ 
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License. 
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/java/com/occamlab/te/web/ViewTestServlet.java
+++ b/teamengine-web/src/main/java/com/occamlab/te/web/ViewTestServlet.java
@@ -1,14 +1,5 @@
 /****************************************************************************
 
- The contents of this file are subject to the Mozilla Public License
- Version 1.1 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
- http://www.mozilla.org/MPL/ 
-
- Software distributed under the License is distributed on an "AS IS" basis,
- WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- the specific language governing rights and limitations under the License. 
-
  The Original Code is TEAM Engine.
 
  The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/resources/com/occamlab/te/web/viewlog.xsl
+++ b/teamengine-web/src/main/resources/com/occamlab/te/web/viewlog.xsl
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/resources/com/occamlab/te/web/viewoldlog.xsl
+++ b/teamengine-web/src/main/resources/com/occamlab/te/web/viewoldlog.xsl
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/resources/com/occamlab/te/web/viewtest.xsl
+++ b/teamengine-web/src/main/resources/com/occamlab/te/web/viewtest.xsl
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/resources/com/occamlab/te/web/viewtestdebug.xsl
+++ b/teamengine-web/src/main/resources/com/occamlab/te/web/viewtestdebug.xsl
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/console.html
+++ b/teamengine-web/src/main/webapp/console.html
@@ -1,14 +1,5 @@
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/createSession.jsp
+++ b/teamengine-web/src/main/webapp/createSession.jsp
@@ -23,15 +23,6 @@
 	}%><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/emailLog.jsp
+++ b/teamengine-web/src/main/webapp/emailLog.jsp
@@ -2,15 +2,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/emailSent.jsp
+++ b/teamengine-web/src/main/webapp/emailSent.jsp
@@ -2,15 +2,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/executing.html
+++ b/teamengine-web/src/main/webapp/executing.html
@@ -1,14 +1,5 @@
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/login.jsp
+++ b/teamengine-web/src/main/webapp/login.jsp
@@ -2,15 +2,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/register.jsp
+++ b/teamengine-web/src/main/webapp/register.jsp
@@ -6,15 +6,6 @@ String email = request.getParameter("email");
 %>
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/registered.jsp
+++ b/teamengine-web/src/main/webapp/registered.jsp
@@ -2,15 +2,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/sessionDeleted.jsp
+++ b/teamengine-web/src/main/webapp/sessionDeleted.jsp
@@ -2,15 +2,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/test.jsp
+++ b/teamengine-web/src/main/webapp/test.jsp
@@ -8,15 +8,6 @@
     java.util.Map<String, String[]> paramMap;
     %><!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     
-      The contents of this file are subject to the Mozilla Public License
-      Version 1.1 (the "License"); you may not use this file except in
-      compliance with the License. You may obtain a copy of the License at
-      http://www.mozilla.org/MPL/ 
-    
-      Software distributed under the License is distributed on an "AS IS" basis,
-      WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-      the specific language governing rights and limitations under the License. 
-    
       The Original Code is TEAM Engine.
     
       The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/testControls.html
+++ b/teamengine-web/src/main/webapp/testControls.html
@@ -1,14 +1,5 @@
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/viewClientTestLog.jsp
+++ b/teamengine-web/src/main/webapp/viewClientTestLog.jsp
@@ -10,15 +10,6 @@
   <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
   <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
   
-    The contents of this file are subject to the Mozilla Public License
-    Version 1.1 (the "License"); you may not use this file except in
-    compliance with the License. You may obtain a copy of the License at
-    http://www.mozilla.org/MPL/ 
-  
-    Software distributed under the License is distributed on an "AS IS" basis,
-    WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-    the specific language governing rights and limitations under the License. 
-  
     The Original Code is TEAM Engine.
   
     The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/viewOldSessionLog.jsp
+++ b/teamengine-web/src/main/webapp/viewOldSessionLog.jsp
@@ -17,14 +17,8 @@ public void jspInit() {
 }
 %><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
   The Original Code is TEAM Engine.
+
   The Initial Developer of the Original Code is Northrop Grumman Corporation
   jointly with The National Technology Alliance.  Portions created by
   Northrop Grumman Corporation are Copyright (C) 2005-2006, Northrop

--- a/teamengine-web/src/main/webapp/viewSessionLog.jsp
+++ b/teamengine-web/src/main/webapp/viewSessionLog.jsp
@@ -21,15 +21,6 @@ public void jspInit() {
 %><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/viewSessions.jsp
+++ b/teamengine-web/src/main/webapp/viewSessions.jsp
@@ -19,15 +19,6 @@
   %><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
   <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
   
-    The contents of this file are subject to the Mozilla Public License
-    Version 1.1 (the "License"); you may not use this file except in
-    compliance with the License. You may obtain a copy of the License at
-    http://www.mozilla.org/MPL/ 
-  
-    Software distributed under the License is distributed on an "AS IS" basis,
-    WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-    the specific language governing rights and limitations under the License. 
-  
     The Original Code is TEAM Engine.
   
     The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/viewTest.jsp
+++ b/teamengine-web/src/main/webapp/viewTest.jsp
@@ -20,15 +20,6 @@ public void jspInit() {
 %><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation

--- a/teamengine-web/src/main/webapp/viewTestLog.jsp
+++ b/teamengine-web/src/main/webapp/viewTestLog.jsp
@@ -21,15 +21,6 @@ public void jspInit() {
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  The contents of this file are subject to the Mozilla Public License
-  Version 1.1 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at
-  http://www.mozilla.org/MPL/ 
-
-  Software distributed under the License is distributed on an "AS IS" basis,
-  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  the specific language governing rights and limitations under the License. 
-
   The Original Code is TEAM Engine.
 
   The Initial Developer of the Original Code is Northrop Grumman Corporation


### PR DESCRIPTION
Comments asserting that the MPL license covers TeamEngine have been removed from all files.