### PR TITLE
Moved vocabulary package from spi to core

### DIFF
--- a/teamengine-core/pom.xml
+++ b/teamengine-core/pom.xml
@@ -22,11 +22,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>teamengine-spi</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.opengis.cite.saxon</groupId>
       <artifactId>saxon9</artifactId>
       <version>${saxon.version}</version>
@@ -53,10 +48,25 @@
       <version>1.2</version>
     </dependency>
     <dependency>
-    <groupId>commons-io</groupId>
-    <artifactId>commons-io</artifactId>
-    <version>2.5</version>
-</dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-core</artifactId>
+      <version>3.1.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-csv</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.5</version>
+    </dependency>
     <dependency>
       <groupId>com.thaiopensource</groupId>
       <artifactId>jing</artifactId>

--- a/teamengine-core/src/main/java/com/occamlab/te/CtlEarlReporter.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/CtlEarlReporter.java
@@ -1,12 +1,13 @@
 /**
- * ********************************************************************************
+ * ***************************************************************************
  *
  * Version Date: January 8, 2018
  *
  * Contributor(s):
  *     C. Heazel (WiSC): Modifications to address Fortify issues
+ *     C. Heazel (WiSC): Moved vocabulary package from spi to core
  *
- * ********************************************************************************
+ * ***************************************************************************
  */
 
 package com.occamlab.te;
@@ -52,10 +53,10 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import com.occamlab.te.spi.vocabulary.CITE;
-import com.occamlab.te.spi.vocabulary.CONTENT;
-import com.occamlab.te.spi.vocabulary.EARL;
-import com.occamlab.te.spi.vocabulary.HTTP;
+import com.occamlab.te.vocabulary.CITE;
+import com.occamlab.te.vocabulary.CONTENT;
+import com.occamlab.te.vocabulary.EARL;
+import com.occamlab.te.vocabulary.HTTP;
 
 public class CtlEarlReporter {
 

--- a/teamengine-core/src/main/java/com/occamlab/te/vocabulary/CITE.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/vocabulary/CITE.java
@@ -1,4 +1,10 @@
-package com.occamlab.te.spi.vocabulary;
+/**********************************************************
+ *
+ *  Contributor(s):
+ *      C. Heazel (WiSC): Moved vocabulary package from spi to core
+ *
+ */
+package com.occamlab.te.vocabulary;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;

--- a/teamengine-core/src/main/java/com/occamlab/te/vocabulary/CONTENT.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/vocabulary/CONTENT.java
@@ -1,4 +1,10 @@
-package com.occamlab.te.spi.vocabulary;
+/************************************************************
+ *
+ * Contributor(s):
+ *     C. Heazel (WiSC): Moved vocabulary package from spi to core
+ *
+ ************************************************************/
+package com.occamlab.te.vocabulary;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;

--- a/teamengine-core/src/main/java/com/occamlab/te/vocabulary/Config.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/vocabulary/Config.java
@@ -9,9 +9,10 @@
  
  Contributor(s): 
  	C. Heazel (WiSC): Added Fortify adjudication changes
+        C. Heazel (WiSC): Moved vocabulary package from spi to core
  
  ****************************************************************************/
-package com.occamlab.te.spi.vocabulary;
+package com.occamlab.te.vocabulary;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/teamengine-core/src/main/java/com/occamlab/te/vocabulary/EARL.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/vocabulary/EARL.java
@@ -1,4 +1,10 @@
-package com.occamlab.te.spi.vocabulary;
+/**************************************************************
+ *
+ * Contributor(s):
+ *     C. Heazel (WiSC): Moved vocabulary package from spi to core
+ *
+ **************************************************************/
+package com.occamlab.te.vocabulary;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;

--- a/teamengine-core/src/main/java/com/occamlab/te/vocabulary/HTTP.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/vocabulary/HTTP.java
@@ -1,4 +1,10 @@
-package com.occamlab.te.spi.vocabulary;
+/**************************************************************
+ *
+ * Contributor(s):
+ *      C. Heazel (WiSC): MOved vocabulary package from spi to core
+ *
+ **************************************************************/
+package com.occamlab.te.vocabulary;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;

--- a/teamengine-core/src/main/java/com/occamlab/te/vocabulary/package-info.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/vocabulary/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Standard vocabulary definitions.
+ *
+ * March 6, 2018 - Moved from spi to core by C. Heazel (WiSC)
+ *
+ */
+package com.occamlab.te.vocabulary;

--- a/teamengine-spi/pom.xml
+++ b/teamengine-spi/pom.xml
@@ -107,6 +107,11 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>teamengine-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.10.19</version>

--- a/teamengine-spi/src/main/java/com/occamlab/te/spi/executors/testng/EarlReporter.java
+++ b/teamengine-spi/src/main/java/com/occamlab/te/spi/executors/testng/EarlReporter.java
@@ -1,3 +1,10 @@
+/********************************************************************
+ *
+ * Contributor(s)
+ *     C. Heazel (WiSC): Moved vocabulary package from spi to core.
+ *
+ *******************************************************************/
+
 package com.occamlab.te.spi.executors.testng;
 
 import java.io.File;
@@ -39,11 +46,11 @@ import org.testng.ITestResult;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
-import com.occamlab.te.spi.vocabulary.CITE;
-import com.occamlab.te.spi.vocabulary.CONTENT;
-import com.occamlab.te.spi.vocabulary.Config;
-import com.occamlab.te.spi.vocabulary.EARL;
-import com.occamlab.te.spi.vocabulary.HTTP;
+import com.occamlab.te.vocabulary.CITE;
+import com.occamlab.te.vocabulary.CONTENT;
+import com.occamlab.te.vocabulary.Config;
+import com.occamlab.te.vocabulary.EARL;
+import com.occamlab.te.vocabulary.HTTP;
 
 
 /**

--- a/teamengine-spi/src/main/java/com/occamlab/te/spi/vocabulary/package-info.java
+++ b/teamengine-spi/src/main/java/com/occamlab/te/spi/vocabulary/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Standard vocabulary definitions.
- */
-package com.occamlab.te.spi.vocabulary;

--- a/teamengine-spi/src/test/java/com/occamlab/te/spi/executors/testng/VerifyEarlReporter.java
+++ b/teamengine-spi/src/test/java/com/occamlab/te/spi/executors/testng/VerifyEarlReporter.java
@@ -1,3 +1,9 @@
+/***************************************************************
+ *
+ * Contributor(s):
+ *    C. Heazel (WiSC): Moved vocabulary package from spi to core
+ *
+ ***************************************************************/
 package com.occamlab.te.spi.executors.testng;
 
 import static org.junit.Assert.*;
@@ -20,7 +26,7 @@ import org.testng.ISuite;
 import org.testng.ITestContext;
 import org.testng.xml.XmlSuite;
 
-import com.occamlab.te.spi.vocabulary.EARL;
+import com.occamlab.te.vocabulary.EARL;
 
 public class VerifyEarlReporter {
 


### PR DESCRIPTION
Moved the vocabulary package from spi to core.  Modified all impacted import statements.  Modified pom.xml files to reflect the change.

Note:  Began having problems (zero arguments returned) with the extractTwoArguments test in VerifyCtlExecutor.java.  Traced the problem to the runOpts.addParam(kvp) line in the extractTestRunArguments() operation in CtlExecutor.java.  After debugging, the problem disappeared without any code changes.