### PR TITLE
Add support for headers when using GET requests

### DIFF
--- a/teamengine-core/src/main/java/com/occamlab/te/TECore.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/TECore.java
@@ -1988,7 +1988,13 @@ public class TECore implements Runnable {
 
       OutputStream os = uc.getOutputStream();
       os.write(bytes);
+    } else {
+      for (int i = 0; i < headers.size(); ++i) {
+        String[] header = headers.get(i);
+        uc.setRequestProperty(header[0], header[1]);
+      }
     }
+
     return uc;
   }
 


### PR DESCRIPTION
This adds support for `<ctl:header>` elements in `<ctl:request>` blocks when using GET requests. Amongst other use cases this allows CTL scripts to use HTTP basic authentication. Fixes part of #46 and can possibly be used to support other header based authentication methods (such as authentication methods with bearer tokens).
