### PR TITLE
Fix inheritance

### DIFF
--- a/teamengine-core/src/main/java/com/occamlab/te/TECore.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/TECore.java
@@ -908,6 +908,7 @@ public class TECore implements Runnable {
         //restore previous verdict if the result isn't worse
         if (this.verdict <= oldVerdict) {
             this.verdict = oldVerdict;
+            test.setResult(verdict);
   }
 
         return test.getResult();


### PR DESCRIPTION
This fixes the inheritance of results with a values `> 1`. This currently doesn't work correctly in certain circumstances, e.g. when passing with warning (result `4`) but the warning node is not the last test in the suite.