### PR TITLE
Bump commons-io and xercesImpl versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
     <saxon.version>9.0.0.8</saxon.version>
+    <jersey.version>1.19</jersey.version>
+    <mockito.version>1.10.19</mockito.version>
   </properties>
 
   <modules>
@@ -120,7 +122,32 @@
         <artifactId>commons-io</artifactId>
         <version>2.5</version>
       </dependency>
-      </dependencies>
+      <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
+        <version>1.4.01</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-core</artifactId>
+        <version>3.1.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
   </dependencyManagement>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,12 @@
         <version>1.0-RC1</version>
         <scope>test</scope>
       </dependency>
-    </dependencies>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.5</version>
+      </dependency>
+      </dependencies>
   </dependencyManagement>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.5</version>
+        <version>2.7</version>
       </dependency>
       <dependency>
         <groupId>xml-apis</groupId>

--- a/teamengine-core/pom.xml
+++ b/teamengine-core/pom.xml
@@ -65,7 +65,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.5</version>
     </dependency>
     <dependency>
       <groupId>com.thaiopensource</groupId>

--- a/teamengine-core/pom.xml
+++ b/teamengine-core/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-      <version>2.12.0</version>
+      <version>2.12.2</version>
     </dependency>
     <dependency>
       <!-- this optional dependency of xercesImpl is generally useful -->

--- a/teamengine-core/pom.xml
+++ b/teamengine-core/pom.xml
@@ -50,17 +50,6 @@
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-core</artifactId>
-      <version>3.1.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-csv</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -120,7 +109,6 @@
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>1.4.01</version>
     </dependency>
 </dependencies>
 

--- a/teamengine-realm/pom.xml
+++ b/teamengine-realm/pom.xml
@@ -24,7 +24,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/teamengine-spi-ctl/pom.xml
+++ b/teamengine-spi-ctl/pom.xml
@@ -47,7 +47,6 @@
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>1.4.01</version>
     </dependency>
   </dependencies>
 

--- a/teamengine-spi/pom.xml
+++ b/teamengine-spi/pom.xml
@@ -61,29 +61,16 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>1.19</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey.contribs</groupId>
       <artifactId>jersey-multipart</artifactId>
-      <version>1.19</version>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-core</artifactId>
-      <version>3.1.0</version>
-      <exclusions>
-        <!-- http://commons.apache.org/proper/commons-csv/ -->
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-csv</artifactId>
-        </exclusion>
-        <!-- http://commons.apache.org/proper/commons-lang/ -->
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -101,7 +88,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -113,7 +99,6 @@
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>1.4.01</version>
     </dependency>
   </dependencies>
 

--- a/teamengine-spi/pom.xml
+++ b/teamengine-spi/pom.xml
@@ -88,7 +88,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.5</version>
 	</dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/teamengine-web/pom.xml
+++ b/teamengine-web/pom.xml
@@ -78,7 +78,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.5</version>
     </dependency>
     <dependency>
       <groupId>javax.activation</groupId>

--- a/teamengine-web/pom.xml
+++ b/teamengine-web/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-servlet</artifactId>
-      <version>1.19</version>
+      <version>${jersey.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -92,12 +92,11 @@
     <dependency>
       <groupId>org.opengis.cite.saxon</groupId>
       <artifactId>saxon9</artifactId>
-      <version>9.0.0.8</version>
+      <version>${saxon.version}</version>
     </dependency>
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>1.4.01</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
[Bump commons-io to version 27, xercesImpl to 2.12.2](https://github.com/opengeospatial/teamengine/commit/817abbc37ce4a0d5b5fc76f0551880130c7c819b)
Includes https://github.com/opengeospatial/teamengine/tree/move-depencency-versions