### PR TITLE
Fix test result logic for results other than PASS/FAIL.

### DIFF
--- a/teamengine-core/src/main/java/com/occamlab/te/RecordTestResult.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/RecordTestResult.java
@@ -348,7 +348,7 @@ public class RecordTestResult {
    * @param dateFormat
    * @throws java.lang.Exception
    */
-  public void storeFinalTestDetail(TestEntry test, int verdict, DateFormat dateFormat, Calendar cal, File dirPath) throws Exception {
+  public void storeFinalTestDetail(TestEntry test, DateFormat dateFormat, Calendar cal, File dirPath) throws Exception {
     // Fortify Mod: make sure that dirPath is a legal path
     // Note: a null dirPath is tolerated
     if( dirPath != null ) {
@@ -364,10 +364,10 @@ public class RecordTestResult {
         String result="";
         JSONObject obj = new JSONObject();
         obj.put(NAME, test.getName());
-        if(getResultDescription(verdict).contains("Inherited")&&test.getName().contains("GetMap")){
+        if(getResultDescription(test.getResult()).contains("Inherited")&&test.getName().contains("GetMap")){
           result="Passed";
         }else{
-          result=getResultDescription(verdict);
+          result=getResultDescription(test.getResult());
         }
         obj.put(RESULT, result);
         obj.put(TIME, dateFormat.format(cal.getTime()));

--- a/teamengine-core/src/main/java/com/occamlab/te/index/IndexEntry.java
+++ b/teamengine-core/src/main/java/com/occamlab/te/index/IndexEntry.java
@@ -18,6 +18,9 @@ public class IndexEntry implements NamedEntry {
     }
 
     public String getName() {
+    	if (qname == null) {
+    		return null;
+    	}
         String prefix = qname.getPrefix();
         if (prefix == null) {
             return qname.getLocalPart();


### PR DESCRIPTION
Fix test result logic for results other than PASS/FAIL.  In particular, WMTS tests that return "Skipped" were causing the parent test to fail.  With this fix, the skipped test will not affect the result of the parent test unless the parent test is a Mandatory test.