### PR TITLE
Add CORS header in process method of MonitorServlet

### DIFF
--- a/teamengine-web/src/main/java/com/occamlab/te/web/MonitorServlet.java
+++ b/teamengine-web/src/main/java/com/occamlab/te/web/MonitorServlet.java
@@ -215,7 +215,7 @@ public class MonitorServlet extends HttpServlet {
             for (Entry<String, List<String>> entry : responseHeaders.entrySet()) {
                 String key = entry.getKey();
                 if (key != null) {
-                    if (key.length() == 0) {
+                    if (key.isEmpty()) {
                         // do nothing
                     } else if (key.equalsIgnoreCase("Transfer-Encoding")) {
                         // do nothing
@@ -226,6 +226,9 @@ public class MonitorServlet extends HttpServlet {
                     }
                 }
             }
+
+            // Support of CORS: Allow requests from all domains.
+            response.setHeader("Access-Control-Allow-Origin", "*");
 
             if (mc.getModifiesResponse()) {
                 LOGR.log(Level.FINE, DomUtils.serializeNode(eResponse));


### PR DESCRIPTION
These HTTP response header parameter and value are set in process method of MonitorServlet:
```
Access-Control-Allow-Origin=*
```

By that, requests are allowed from all domains when using the MonitorServlet.

The only test suite currently using this functionality should be [ets-wms-client13](https://github.com/opengeospatial/ets-wms-client13).

Original issue describing the problem: https://github.com/opengeospatial/ets-wms-client13/issues/66

Closes https://github.com/opengeospatial/ets-wms-client13/issues/66