### PR TITLE
Correct target folder for mounting JAR dependencies in teamengine-web

### DIFF
--- a/teamengine-web/src/main/webapp/META-INF/context.xml
+++ b/teamengine-web/src/main/webapp/META-INF/context.xml
@@ -16,7 +16,7 @@
   <Resources>
           <PreResources base="${TE_BASE}/resources/lib"
                         className="org.apache.catalina.webresources.DirResourceSet"
-                        webAppMount="/WEB-INF/classes"/>
+                        webAppMount="/WEB-INF/lib"/>
           <PreResources base="${TE_BASE}/resources/docs"
                         className="org.apache.catalina.webresources.DirResourceSet"
                         webAppMount="/docs"/>


### PR DESCRIPTION
This small change corrects the target folder for mounting JAR files in the web version of teamengine.

Tomcat expects JAR dependencies in WEB-INF/lib and unpacked .class files in WEB-INF/classes. 

While the current version would work if ${TE_BASE}/resources/lib contains unpacked .class files instead of JAR files, [teamengine usage instructions](https://opengeospatial.github.io/teamengine/users.html) suggest putting dependencies as JAR files in ${TE_BASE}/resources/lib. The default build output from the template generated from the [ETS maven archetype](https://github.com/opengeospatial/ets-archetype-testng) also packages dependencies as JAR files.

This change thus avoids the need to copy JAR files directly into the WEB-INF/lib folder during development or change the build output in the ETS code.